### PR TITLE
Add the ability to parse signals based on a platform string

### DIFF
--- a/signals.go
+++ b/signals.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/platforms"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -48,10 +49,6 @@ func GetStopSignal(ctx context.Context, container Container, defaultSignal sysca
 
 // GetOCIStopSignal retrieves the stop signal specified in the OCI image config
 func GetOCIStopSignal(ctx context.Context, image Image, defaultSignal string) (string, error) {
-	_, err := ParseSignal(defaultSignal)
-	if err != nil {
-		return "", err
-	}
 	ic, err := image.Config(ctx)
 	if err != nil {
 		return "", err
@@ -59,6 +56,7 @@ func GetOCIStopSignal(ctx context.Context, image Image, defaultSignal string) (s
 	var (
 		ociimage v1.Image
 		config   v1.ImageConfig
+		platform string = platforms.DefaultSpec().OS
 	)
 	switch ic.MediaType {
 	case v1.MediaTypeImageConfig, images.MediaTypeDockerSchema2Config:
@@ -71,8 +69,14 @@ func GetOCIStopSignal(ctx context.Context, image Image, defaultSignal string) (s
 			return "", err
 		}
 		config = ociimage.Config
+		platform = ociimage.OS
 	default:
 		return "", fmt.Errorf("unknown image config media type %s", ic.MediaType)
+	}
+
+	// verify that default signal is valid
+	if _, err := ParsePlatformSignal(defaultSignal, platform); err != nil {
+		return "", err
 	}
 
 	if config.StopSignal == "" {

--- a/signals_unix.go
+++ b/signals_unix.go
@@ -31,6 +31,14 @@ import (
 // the rawSignal can be a string with "SIG" prefix,
 // or a signal number in string format.
 func ParseSignal(rawSignal string) (syscall.Signal, error) {
+	return parseSignalUnix(rawSignal)
+}
+
+func ParsePlatformSignal(rawSignal string, _ string) (syscall.Signal, error) {
+	return parseSignalUnix(rawSignal)
+}
+
+func parseSignalUnix(rawSignal string) (syscall.Signal, error) {
 	s, err := strconv.Atoi(rawSignal)
 	if err == nil {
 		return syscall.Signal(s), nil

--- a/signals_windows.go
+++ b/signals_windows.go
@@ -25,26 +25,114 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-var signalMap = map[string]syscall.Signal{
-	"HUP":    syscall.Signal(windows.SIGHUP),
-	"INT":    syscall.Signal(windows.SIGINT),
-	"QUIT":   syscall.Signal(windows.SIGQUIT),
-	"SIGILL": syscall.Signal(windows.SIGILL),
-	"TRAP":   syscall.Signal(windows.SIGTRAP),
-	"ABRT":   syscall.Signal(windows.SIGABRT),
-	"BUS":    syscall.Signal(windows.SIGBUS),
-	"FPE":    syscall.Signal(windows.SIGFPE),
-	"KILL":   syscall.Signal(windows.SIGKILL),
-	"SEGV":   syscall.Signal(windows.SIGSEGV),
-	"PIPE":   syscall.Signal(windows.SIGPIPE),
-	"ALRM":   syscall.Signal(windows.SIGALRM),
-	"TERM":   syscall.Signal(windows.SIGTERM),
+const (
+	linuxSigrtmin = 34
+	linuxSigrtmax = 64
+)
+
+var signalMapWindows = map[string]syscall.Signal{
+	"HUP":  syscall.Signal(windows.SIGHUP),
+	"INT":  syscall.Signal(windows.SIGINT),
+	"QUIT": syscall.Signal(windows.SIGQUIT),
+	"ILL":  syscall.Signal(windows.SIGILL),
+	"TRAP": syscall.Signal(windows.SIGTRAP),
+	"ABRT": syscall.Signal(windows.SIGABRT),
+	"BUS":  syscall.Signal(windows.SIGBUS),
+	"FPE":  syscall.Signal(windows.SIGFPE),
+	"KILL": syscall.Signal(windows.SIGKILL),
+	"SEGV": syscall.Signal(windows.SIGSEGV),
+	"PIPE": syscall.Signal(windows.SIGPIPE),
+	"ALRM": syscall.Signal(windows.SIGALRM),
+	"TERM": syscall.Signal(windows.SIGTERM),
+}
+
+// manually define signals for linux since we may be running an LCOW container, but
+// the unix syscalls do not get built when running on windows
+var signalMapLinux = map[string]syscall.Signal{
+	"ABRT":     syscall.Signal(0x6),
+	"ALRM":     syscall.Signal(0xe),
+	"BUS":      syscall.Signal(0x7),
+	"CHLD":     syscall.Signal(0x11),
+	"CLD":      syscall.Signal(0x11),
+	"CONT":     syscall.Signal(0x12),
+	"FPE":      syscall.Signal(0x8),
+	"HUP":      syscall.Signal(0x1),
+	"ILL":      syscall.Signal(0x4),
+	"INT":      syscall.Signal(0x2),
+	"IO":       syscall.Signal(0x1d),
+	"IOT":      syscall.Signal(0x6),
+	"KILL":     syscall.Signal(0x9),
+	"PIPE":     syscall.Signal(0xd),
+	"POLL":     syscall.Signal(0x1d),
+	"PROF":     syscall.Signal(0x1b),
+	"PWR":      syscall.Signal(0x1e),
+	"QUIT":     syscall.Signal(0x3),
+	"SEGV":     syscall.Signal(0xb),
+	"STKFLT":   syscall.Signal(0x10),
+	"STOP":     syscall.Signal(0x13),
+	"SYS":      syscall.Signal(0x1f),
+	"TERM":     syscall.Signal(0xf),
+	"TRAP":     syscall.Signal(0x5),
+	"TSTP":     syscall.Signal(0x14),
+	"TTIN":     syscall.Signal(0x15),
+	"TTOU":     syscall.Signal(0x16),
+	"URG":      syscall.Signal(0x17),
+	"USR1":     syscall.Signal(0xa),
+	"USR2":     syscall.Signal(0xc),
+	"VTALRM":   syscall.Signal(0x1a),
+	"WINCH":    syscall.Signal(0x1c),
+	"XCPU":     syscall.Signal(0x18),
+	"XFSZ":     syscall.Signal(0x19),
+	"RTMIN":    linuxSigrtmin,
+	"RTMIN+1":  linuxSigrtmin + 1,
+	"RTMIN+2":  linuxSigrtmin + 2,
+	"RTMIN+3":  linuxSigrtmin + 3,
+	"RTMIN+4":  linuxSigrtmin + 4,
+	"RTMIN+5":  linuxSigrtmin + 5,
+	"RTMIN+6":  linuxSigrtmin + 6,
+	"RTMIN+7":  linuxSigrtmin + 7,
+	"RTMIN+8":  linuxSigrtmin + 8,
+	"RTMIN+9":  linuxSigrtmin + 9,
+	"RTMIN+10": linuxSigrtmin + 10,
+	"RTMIN+11": linuxSigrtmin + 11,
+	"RTMIN+12": linuxSigrtmin + 12,
+	"RTMIN+13": linuxSigrtmin + 13,
+	"RTMIN+14": linuxSigrtmin + 14,
+	"RTMIN+15": linuxSigrtmin + 15,
+	"RTMAX-14": linuxSigrtmax - 14,
+	"RTMAX-13": linuxSigrtmax - 13,
+	"RTMAX-12": linuxSigrtmax - 12,
+	"RTMAX-11": linuxSigrtmax - 11,
+	"RTMAX-10": linuxSigrtmax - 10,
+	"RTMAX-9":  linuxSigrtmax - 9,
+	"RTMAX-8":  linuxSigrtmax - 8,
+	"RTMAX-7":  linuxSigrtmax - 7,
+	"RTMAX-6":  linuxSigrtmax - 6,
+	"RTMAX-5":  linuxSigrtmax - 5,
+	"RTMAX-4":  linuxSigrtmax - 4,
+	"RTMAX-3":  linuxSigrtmax - 3,
+	"RTMAX-2":  linuxSigrtmax - 2,
+	"RTMAX-1":  linuxSigrtmax - 1,
+	"RTMAX":    linuxSigrtmax,
 }
 
 // ParseSignal parses a given string into a syscall.Signal
 // the rawSignal can be a string with "SIG" prefix,
 // or a signal number in string format.
 func ParseSignal(rawSignal string) (syscall.Signal, error) {
+	return parseSignalFromMap(rawSignal, signalMapWindows)
+}
+
+// ParsePlatformSignal parses a given string into a syscall.Signal based on
+// the OS platform specified in `platform`.
+func ParsePlatformSignal(rawSignal, platform string) (syscall.Signal, error) {
+	if platform != "windows" {
+		return parseSignalFromMap(rawSignal, signalMapLinux)
+	}
+	return parseSignalFromMap(rawSignal, signalMapWindows)
+}
+
+func parseSignalFromMap(rawSignal string, signalMap map[string]syscall.Signal) (syscall.Signal, error) {
 	s, err := strconv.Atoi(rawSignal)
 	if err == nil {
 		sig := syscall.Signal(s)

--- a/signals_windows_test.go
+++ b/signals_windows_test.go
@@ -1,3 +1,5 @@
+// +build windows
+
 /*
    Copyright The containerd Authors.
 
@@ -22,30 +24,7 @@ import (
 	"testing"
 )
 
-func TestParseSignal(t *testing.T) {
-	testSignals := []struct {
-		raw  string
-		want syscall.Signal
-		err  bool
-	}{
-		{"1", syscall.Signal(1), false},
-		{"SIGKILL", syscall.SIGKILL, false},
-		{"NONEXIST", 0, true},
-	}
-	for _, ts := range testSignals {
-		t.Run(fmt.Sprintf("%s/%d/%t", ts.raw, ts.want, ts.err), func(t *testing.T) {
-			got, err := ParseSignal(ts.raw)
-			if ts.err && err == nil {
-				t.Errorf("ParseSignal(%s) should return error", ts.raw)
-			}
-			if !ts.err && got != ts.want {
-				t.Errorf("ParseSignal(%s) return %d, want %d", ts.raw, got, ts.want)
-			}
-		})
-	}
-}
-
-func TestParsePlatformSignalGeneric(t *testing.T) {
+func TestParsePlatformSignalOnWindows(t *testing.T) {
 	testSignals := []struct {
 		raw      string
 		want     syscall.Signal
@@ -57,15 +36,25 @@ func TestParsePlatformSignalGeneric(t *testing.T) {
 		{"SIGKILL", syscall.SIGKILL, "linux", false},
 		{"NONEXIST", 0, "linux", true},
 		{"65536", 0, "linux", true},
+
+		// test signals for windows platform
+		{"1", syscall.Signal(1), "windows", false},
+		{"SIGKILL", syscall.SIGKILL, "windows", false},
+		{"NONEXIST", 0, "windows", true},
+		{"65536", 0, "windows", true},
+
+		// make sure signals from opposing platform do not resolve
+		{"SIGWINCH", 0, "windows", true},
+		{"SIGWINCH", syscall.Signal(0x1c), "linux", false},
 	}
 	for _, ts := range testSignals {
 		t.Run(fmt.Sprintf("%s/%d/%s/%t", ts.raw, ts.want, ts.platform, ts.err), func(t *testing.T) {
 			got, err := ParsePlatformSignal(ts.raw, ts.platform)
 			if ts.err && err == nil {
-				t.Errorf("ParseSignal(%s) should return error", ts.raw)
+				t.Errorf("ParsePlatformSignal(%s) should return error", ts.raw)
 			}
 			if !ts.err && got != ts.want {
-				t.Errorf("ParseSignal(%s) return %d, want %d", ts.raw, got, ts.want)
+				t.Errorf("ParsePlatformSignal(%s) return %d, want %d", ts.raw, got, ts.want)
 			}
 		})
 	}


### PR DESCRIPTION
This PR fixes a bug where parsing signals for LCOW would use windows signals, since the platform running is windows. Since unix packages do no build and cannot be used on windows, we cannot use the default signals and signal parsing in golang packages. Instead, we manually specify a list of unix signals to support, on par with the linux signals supported in docker [here](https://github.com/docker/docker-ce/blob/master/components/engine/pkg/signal/signal_linux.go). 

Added test to verify added support in this PR. 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>