### PR TITLE
Match signal parse behavior for LCOW 

### DIFF
--- a/signals_test.go
+++ b/signals_test.go
@@ -56,7 +56,7 @@ func TestParsePlatformSignalGeneric(t *testing.T) {
 		{"1", syscall.Signal(1), "linux", false},
 		{"SIGKILL", syscall.SIGKILL, "linux", false},
 		{"NONEXIST", 0, "linux", true},
-		{"65536", 0, "linux", true},
+		{"65536", syscall.Signal(65536), "linux", false},
 	}
 	for _, ts := range testSignals {
 		t.Run(fmt.Sprintf("%s/%d/%s/%t", ts.raw, ts.want, ts.platform, ts.err), func(t *testing.T) {

--- a/signals_windows_test.go
+++ b/signals_windows_test.go
@@ -35,7 +35,7 @@ func TestParsePlatformSignalOnWindows(t *testing.T) {
 		{"1", syscall.Signal(1), "linux", false},
 		{"SIGKILL", syscall.SIGKILL, "linux", false},
 		{"NONEXIST", 0, "linux", true},
-		{"65536", 0, "linux", true},
+		{"65536", syscall.Signal(65536), "linux", false},
 
 		// test signals for windows platform
 		{"1", syscall.Signal(1), "windows", false},


### PR DESCRIPTION
Since containerd uses syscall.Signal(x) for generic signal parsing of numerical values, there is no error check for the value not mapping to a standard signal. Match the behavior for linux signals when running on linux or windows. 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>