### PR TITLE
[fork/release/1.4] Dump each goroutine stack as a separate log message

### DIFF
--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -25,6 +25,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/containerd/containerd/errdefs"
@@ -314,7 +315,15 @@ func dumpStacks(writeToFile bool) {
 		bufferLen *= 2
 	}
 	buf = buf[:stackSize]
-	logrus.Infof("=== BEGIN goroutine stack dump ===\n%s\n=== END goroutine stack dump ===", buf)
+	stacks := strings.Split(string(buf), "\n\n")
+	logrus.WithField("stackCount", len(stacks)).Info("Begin goroutine stack dump")
+	for i, stack := range stacks {
+		logrus.WithFields(logrus.Fields{
+			"index": i,
+			"stack": stack,
+		}).Info("Dumping goroutine stack")
+	}
+	logrus.Info("End goroutine stack dump")
 
 	if writeToFile {
 		// Also write to file to aid gathering diagnostics


### PR DESCRIPTION
This changes the stack dumping code so that we split the giant string
containing every goroutine's stack and log each stack as a separate log
message. This makes the output easier to parse, and especially helps in
cases where the log output is sent through a system with a log message
size limit, such as Windows's ETW.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>
(cherry picked from commit dbb117bc9cef51867db461ac61a489627630caf0)
Signed-off-by: Kevin Parsons <kevpar@microsoft.com>