### PR TITLE
[fork/release/1.4] Backport ctr image pull support to print image chain ID

### DIFF
--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -25,6 +25,7 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/platforms"
+	"github.com/opencontainers/image-spec/identity"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
@@ -56,6 +57,10 @@ command. As part of this process, we do the following:
 		cli.BoolFlag{
 			Name:  "all-metadata",
 			Usage: "Pull metadata for all platforms",
+		},
+		cli.BoolFlag{
+			Name:  "print-chainid",
+			Usage: "Print the resulting image's chain ID",
 		},
 	),
 	Action: func(context *cli.Context) error {
@@ -117,6 +122,14 @@ command. As part of this process, we do the following:
 			err = i.Unpack(ctx, context.String("snapshotter"))
 			if err != nil {
 				return err
+			}
+			if context.Bool("print-chainid") {
+				diffIDs, err := i.RootFS(ctx)
+				if err != nil {
+					return err
+				}
+				chainID := identity.ChainID(diffIDs).String()
+				fmt.Printf("image chain ID: %s\n", chainID)
 			}
 		}
 

--- a/cmd/ctr/commands/snapshots/snapshots.go
+++ b/cmd/ctr/commands/snapshots/snapshots.go
@@ -280,6 +280,10 @@ var prepareCommand = cli.Command{
 			Name:  "target, t",
 			Usage: "mount target path, will print mount, if provided",
 		},
+		cli.BoolFlag{
+			Name:  "mounts",
+			Usage: "Print out snapshot mounts as JSON",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		if narg := context.NArg(); narg < 1 || narg > 2 {
@@ -310,6 +314,10 @@ var prepareCommand = cli.Command{
 			printMounts(target, mounts)
 		}
 
+		if context.Bool("mounts") {
+			commands.PrintAsJSON(mounts)
+		}
+
 		return nil
 	},
 }
@@ -322,6 +330,10 @@ var viewCommand = cli.Command{
 		cli.StringFlag{
 			Name:  "target, t",
 			Usage: "mount target path, will print mount, if provided",
+		},
+		cli.BoolFlag{
+			Name:  "mounts",
+			Usage: "Print out snapshot mounts as JSON",
 		},
 	},
 	Action: func(context *cli.Context) error {
@@ -347,6 +359,10 @@ var viewCommand = cli.Command{
 
 		if target != "" {
 			printMounts(target, mounts)
+		}
+
+		if context.Bool("mounts") {
+			commands.PrintAsJSON(mounts)
 		}
 
 		return nil


### PR DESCRIPTION
This PR is a cherry-pick of https://github.com/containerd/containerd/pull/4848, see original PR for more info. 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>