### PR TITLE
Snapshotter cleanup fix

### DIFF
--- a/snapshots/lcow/lcow.go
+++ b/snapshots/lcow/lcow.go
@@ -231,7 +231,14 @@ func (s *snapshotter) Remove(ctx context.Context, key string) error {
 	path := s.getSnapshotDir(id)
 	renamed := s.getSnapshotDir("rm-" + id)
 	if err := os.Rename(path, renamed); err != nil && !os.IsNotExist(err) {
-		return err
+		// Sometimes if there are some open handles to the files (especially VHD)
+		// inside the snapshot directory the rename call will return "access
+		// denied" or "file is being used by another process" errors.  Just
+		// returning that error causes the entire snapshot garbage collection
+		// operation to fail. To avoid that we return failed pre-condition error
+		// here so that snapshot garbage collection can continue and can cleanup
+		// other snapshots.
+		return errors.Wrap(errdefs.ErrFailedPrecondition, err.Error())
 	}
 
 	if err := t.Commit(); err != nil {


### PR DESCRIPTION
During snapshotter cleanup lcow/wcow snapshotters try to rename the snapshot directory
before cleaning it up. This rename operation sometimes fails if the sandbox.vhdx file
inside that directory is still open in some process (ideally it should not be open but can
stay open in case of a crash or exception). However, if this rename operation fails we
return that error and then the entire snapshot garbage collection operation fails. Due to
this we end up no cleaning other snapshots which otherwise could have been cleaned up
without any errors. If this goes on for a long time we will end up filling the entire disk
with stale snapshots. This change fixes that issues by continuing the snapshot cleanup if
the rename operation fails because of such open handles.

Signed-off-by: Amit Barve <ambarve@microsoft.com>