### PR TITLE
Add option to skip unpacking the same layer in parallel

### DIFF
--- a/client.go
+++ b/client.go
@@ -352,6 +352,10 @@ type RemoteContext struct {
 	// AllMetadata downloads all manifests and known-configuration files
 	AllMetadata bool
 
+	// DisableSameLayerUnpack prevents a parallel unpack of the same image layer and will wait for the first
+	// in line to complete before either returning the error if there was one, or returning ErrAlreadyExists.
+	DisableSameLayerUnpack bool
+
 	// ChildLabelMap sets the labels used to reference child objects in the content
 	// store. By default, all GC reference labels will be set for all fetched content.
 	ChildLabelMap func(ocispec.Descriptor) []string

--- a/client_opts.go
+++ b/client_opts.go
@@ -228,6 +228,15 @@ func WithMaxConcurrentDownloads(max int) RemoteOpt {
 	}
 }
 
+func WithDisableSameLayerUnpack() RemoteOpt {
+	return func(client *Client, c *RemoteContext) error {
+		c.DisableSameLayerUnpack = true
+		c.SnapshotterOpts = append(c.SnapshotterOpts,
+			snapshots.WithLabels(map[string]string{"containerd.io/snapshot/disable-same-unpack": ""}))
+		return nil
+	}
+}
+
 // WithAllMetadata downloads all manifests and known-configuration files
 func WithAllMetadata() RemoteOpt {
 	return func(_ *Client, c *RemoteContext) error {

--- a/metadata/snapshot.go
+++ b/metadata/snapshot.go
@@ -37,15 +37,31 @@ import (
 )
 
 const (
-	inheritedLabelsPrefix = "containerd.io/snapshot/"
-	labelSnapshotRef      = "containerd.io/snapshot.ref"
+	inheritedLabelsPrefix  = "containerd.io/snapshot/"
+	labelSnapshotRef       = "containerd.io/snapshot.ref"
+	labelDisableSameUnpack = "containerd.io/snapshot/disable-same-unpack"
 )
+
+type broadcaster struct {
+	c      *sync.Cond
+	remove bool
+	err    error
+}
+
+func newBroadcaster() *broadcaster {
+	return &broadcaster{
+		c: sync.NewCond(&sync.Mutex{}),
+	}
+}
 
 type snapshotter struct {
 	snapshots.Snapshotter
 	name string
 	db   *DB
 	l    sync.RWMutex
+	// inProgress holds all active extraction snapshots before becoming commited/removed. This can be used to wait on the
+	// result of an unpack instead of doing the same work twice if one is already inflight.
+	inProgress map[string]*broadcaster
 }
 
 // newSnapshotter returns a new Snapshotter which namespaces the given snapshot
@@ -55,6 +71,7 @@ func newSnapshotter(db *DB, name string, sn snapshots.Snapshotter) *snapshotter 
 		Snapshotter: sn,
 		name:        name,
 		db:          db,
+		inProgress:  make(map[string]*broadcaster),
 	}
 }
 
@@ -281,7 +298,7 @@ func (s *snapshotter) View(ctx context.Context, key, parent string, opts ...snap
 	return s.createSnapshot(ctx, key, parent, true, opts)
 }
 
-func (s *snapshotter) createSnapshot(ctx context.Context, key, parent string, readonly bool, opts []snapshots.Opt) ([]mount.Mount, error) {
+func (s *snapshotter) createSnapshot(ctx context.Context, key, parent string, readonly bool, opts []snapshots.Opt) (_ []mount.Mount, err error) {
 	s.l.RLock()
 	defer s.l.RUnlock()
 
@@ -302,13 +319,50 @@ func (s *snapshotter) createSnapshot(ctx context.Context, key, parent string, re
 	}
 
 	var (
-		target  = base.Labels[labelSnapshotRef]
-		bparent string
-		bkey    string
-		bopts   = []snapshots.Opt{
+		target               = base.Labels[labelSnapshotRef]
+		_, disableSameUnpack = base.Labels[labelDisableSameUnpack]
+		bparent              string
+		bkey                 string
+		bopts                = []snapshots.Opt{
 			snapshots.WithLabels(snapshots.FilterInheritedLabels(base.Labels)),
 		}
 	)
+
+	if disableSameUnpack {
+		broadcaster, ok := s.inProgress[key]
+		if ok {
+			broadcaster.c.L.Lock()
+			// Wait for someone to broadcast that the active snapshot was either committed or removed.
+			broadcaster.c.Wait()
+			// If the extraction snapshot we were waiting on wasn't removed, then it either
+			// 1. Succeeded and we return ErrAlreadyExists
+			// 2. Failed and we return the error as is.
+			if !broadcaster.remove {
+				// Grab the error and if nil return ErrAlreadyExists to match the behavior of if we statted a
+				// snapshot that already exists. The client will have to have behavior to skip applying a diff
+				// on ErrAlreadyExists (which is true for schema 2 images/Unpacker). This is the same mechanism
+				// remote snapshotters employ also.
+				err = errdefs.ErrAlreadyExists
+				if broadcaster.err != nil {
+					err = broadcaster.err
+				}
+				broadcaster.c.L.Unlock()
+				return nil, err
+			}
+			broadcaster.c.L.Unlock()
+		} else {
+			// Else add the target to in progress.
+			bc := newBroadcaster()
+			s.inProgress[key] = bc
+			defer func() {
+				if err != nil {
+					bc.err = err
+					bc.c.Broadcast()
+					delete(s.inProgress, target)
+				}
+			}()
+		}
+	}
 
 	if err := update(ctx, s.db, func(tx *bolt.Tx) error {
 		bkt, err := createSnapshotterBucket(tx, ns, s.name)
@@ -492,9 +546,22 @@ func (s *snapshotter) createSnapshot(ctx context.Context, key, parent string, re
 	return m, nil
 }
 
-func (s *snapshotter) Commit(ctx context.Context, name, key string, opts ...snapshots.Opt) error {
+func (s *snapshotter) Commit(ctx context.Context, name, key string, opts ...snapshots.Opt) (err error) {
 	s.l.RLock()
 	defer s.l.RUnlock()
+
+	defer func() {
+		broadcaster, ok := s.inProgress[key]
+		if ok {
+			broadcaster.c.L.Lock()
+			// Set the error that commit will return and then broadcast to all waiters that a commit has successfully
+			// completed/failed.
+			broadcaster.err = err
+			broadcaster.c.Broadcast()
+			broadcaster.c.L.Unlock()
+		}
+		delete(s.inProgress, key)
+	}()
 
 	ns, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {
@@ -623,9 +690,24 @@ func (s *snapshotter) Commit(ctx context.Context, name, key string, opts ...snap
 
 }
 
-func (s *snapshotter) Remove(ctx context.Context, key string) error {
+func (s *snapshotter) Remove(ctx context.Context, key string) (err error) {
 	s.l.RLock()
 	defer s.l.RUnlock()
+
+	defer func() {
+		// If an active snapshot that was going to have a diff applied (or already did) is being removed we need to alert any waiters.
+		// We need to have logic to move on with creating a snapshot instead of returning from Prepare with ErrAlreadyExists, this is the role
+		// the remove field fulfills.
+		broadcaster, ok := s.inProgress[key]
+		if ok {
+			broadcaster.c.L.Lock()
+			broadcaster.remove = true
+			broadcaster.c.Broadcast()
+			broadcaster.c.L.Unlock()
+		}
+		// No harm in always deleting even if the key doesn't exist, just a no-op.
+		delete(s.inProgress, key)
+	}()
 
 	ns, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {

--- a/unpacker.go
+++ b/unpacker.go
@@ -137,8 +137,15 @@ EachLayer:
 		)
 
 		for try := 1; try <= 3; try++ {
+			// If we want to avoid unpacking the same layer in parallel, we need to use a key format that will
+			// intentionally cause collisions for the same layer. This is how we'll know an active snapshot is
+			// underway already, along with intentional tracking in the metadata snapshotter layer.
+			if rCtx.DisableSameLayerUnpack {
+				key = fmt.Sprintf(snapshots.UnpackKeyPrefix+"-%s", chainID)
+			} else {
+				key = fmt.Sprintf(snapshots.UnpackKeyFormat, uniquePart(), chainID)
+			}
 			// Prepare snapshot with from parent, label as root
-			key = fmt.Sprintf(snapshots.UnpackKeyFormat, uniquePart(), chainID)
 			mounts, err = sn.Prepare(ctx, key, parent.String(), opts...)
 			if err != nil {
 				if errdefs.IsAlreadyExists(err) {


### PR DESCRIPTION
With the way things work right now, there's nothing stopping a parallel unpack of the exact
same layer to a snapshot. The first one to get committed will live on while the other(s) get garbage collected
so in the end things work out, but regardless of this it's wasted work. The real issue is that while unpack
should be pretty cheap on Linux, the opposite is true for the Windows and lcow formats. Kicking off
10 parallel pulls of the same image brings my 6 core machine to a halt and pushes 100% cpu utilization.
What all of this ends up causing is exponentially slower parallel pull times for images that either share layers,
or just pulling the same image.

I'm not sure if this is a "sound" way to approach this, or if there's possibly a much easier way to go about this change. I tried
to model it in a way that wouldn't disrupt things from a clients perspective, so the logic lives in the metadata snapshotter
layer. The gist of this change is if a new RemoteContext option is specified, the snapshotter now keeps track of what active
snapshots are "in progress". Any other snapshots that call Prepare with the same key as a snapshot that is already in progress
will now simply wait for one of two things to occur.
1. The first active snapshot it's waiting on gets removed via `Remove` (so it was never committed). For this case there
was likely an error during setup for the first snapshot/unpack, so any waiters continue as normal for this branch and create a new snapshot.
2. First active snapshot gets committed and will notify any snapshots currently waiting that commit has succeeded and
we can simply exit (as the layer now exists, so no need to create a new snapshot+unpack again). ErrAlreadyExists is returned from
all of the snapshots waiting to let the client know that there's already a snapshot that exists with this content.

Below are some numbers from testing this fix vs. Containerd built from main.:

Single Pull With This Commit
PS C:\Users\dcanter\Desktop\ctrd> $a=1..1 | %{start-job {C:\Users\dcanter\Desktop\ctrd\crictl.exe pull cplatpublic.azurecr.io/nanoserver_many_layers:latest}}; $a | wait-job | receive-job; $a | %{$_.psendtime-$_.psbegintime} | % totalseconds
Image is up to date for sha256:f86afbf779d83cf5aa2cc8377ea0b9f1cea140de22e1189270634d3a8ca4cf0e
23.2647532


10 Parallel Pulls With This Commit
PS C:\Users\dcanter\Desktop\ctrd> $a=1..10 | %{start-job {C:\Users\dcanter\Desktop\ctrd\crictl.exe pull cplatpublic.azurecr.io/nanoserver_many_layers:latest}}; $a | wait-job | receive-job; $a | %{$_.psendtime-$_.psbegintime} | % totalseconds
Image is up to date for sha256:f86afbf779d83cf5aa2cc8377ea0b9f1cea140de22e1189270634d3a8ca4cf0e
Image is up to date for sha256:f86afbf779d83cf5aa2cc8377ea0b9f1cea140de22e1189270634d3a8ca4cf0e
Image is up to date for sha256:f86afbf779d83cf5aa2cc8377ea0b9f1cea140de22e1189270634d3a8ca4cf0e
Image is up to date for sha256:f86afbf779d83cf5aa2cc8377ea0b9f1cea140de22e1189270634d3a8ca4cf0e
Image is up to date for sha256:f86afbf779d83cf5aa2cc8377ea0b9f1cea140de22e1189270634d3a8ca4cf0e
Image is up to date for sha256:f86afbf779d83cf5aa2cc8377ea0b9f1cea140de22e1189270634d3a8ca4cf0e
Image is up to date for sha256:f86afbf779d83cf5aa2cc8377ea0b9f1cea140de22e1189270634d3a8ca4cf0e
Image is up to date for sha256:f86afbf779d83cf5aa2cc8377ea0b9f1cea140de22e1189270634d3a8ca4cf0e
Image is up to date for sha256:f86afbf779d83cf5aa2cc8377ea0b9f1cea140de22e1189270634d3a8ca4cf0e
Image is up to date for sha256:f86afbf779d83cf5aa2cc8377ea0b9f1cea140de22e1189270634d3a8ca4cf0e
25.3406896
25.1486873
25.0266887
24.8586885
24.7116929
24.5726943
24.4816912
24.375693
24.250694
24.1176895


10 Parallel Pulls With Containerd Built Off Main (No Windows defender exclusion on data directory):
PS C:\Users\dcanter\Desktop\ctrd> $a=1..10 | %{start-job {C:\Users\dcanter\Desktop\ctrd\crictl.exe pull cplatpublic.azurecr.io/nanoserver_many_layers:latest}}; $a | wait-job | receive-job; $a | %{$_.psendtime-$_.psbegintime} | % totalseconds
Image is up to date for sha256:f86afbf779d83cf5aa2cc8377ea0b9f1cea140de22e1189270634d3a8ca4cf0e
Image is up to date for sha256:f86afbf779d83cf5aa2cc8377ea0b9f1cea140de22e1189270634d3a8ca4cf0e
Image is up to date for sha256:f86afbf779d83cf5aa2cc8377ea0b9f1cea140de22e1189270634d3a8ca4cf0e
Image is up to date for sha256:f86afbf779d83cf5aa2cc8377ea0b9f1cea140de22e1189270634d3a8ca4cf0e
Image is up to date for sha256:f86afbf779d83cf5aa2cc8377ea0b9f1cea140de22e1189270634d3a8ca4cf0e
Image is up to date for sha256:f86afbf779d83cf5aa2cc8377ea0b9f1cea140de22e1189270634d3a8ca4cf0e
Image is up to date for sha256:f86afbf779d83cf5aa2cc8377ea0b9f1cea140de22e1189270634d3a8ca4cf0e
Image is up to date for sha256:f86afbf779d83cf5aa2cc8377ea0b9f1cea140de22e1189270634d3a8ca4cf0e
Image is up to date for sha256:f86afbf779d83cf5aa2cc8377ea0b9f1cea140de22e1189270634d3a8ca4cf0e
Image is up to date for sha256:f86afbf779d83cf5aa2cc8377ea0b9f1cea140de22e1189270634d3a8ca4cf0e
134.416318
134.2893209
134.1643238
134.027323
133.8813211
133.7333303
133.5593271
133.4253269
133.2963282
133.1643288


10 Parallel Pulls With Containerd Built Off Main (With Windows defender exclusion on data directory):
PS C:\Users\dcanter\Desktop\ctrd> $a=1..10 | %{start-job {C:\Users\dcanter\Desktop\ctrd\crictl.exe pull cplatpublic.azurecr.io/nanoserver_many_layers:latest}}; $a | wait-job | receive-job; $a | %{$_.psendtime-$_.psbegintime} | % totalseconds
Image is up to date for sha256:f86afbf779d83cf5aa2cc8377ea0b9f1cea140de22e1189270634d3a8ca4cf0e
Image is up to date for sha256:f86afbf779d83cf5aa2cc8377ea0b9f1cea140de22e1189270634d3a8ca4cf0e
Image is up to date for sha256:f86afbf779d83cf5aa2cc8377ea0b9f1cea140de22e1189270634d3a8ca4cf0e
Image is up to date for sha256:f86afbf779d83cf5aa2cc8377ea0b9f1cea140de22e1189270634d3a8ca4cf0e
Image is up to date for sha256:f86afbf779d83cf5aa2cc8377ea0b9f1cea140de22e1189270634d3a8ca4cf0e
Image is up to date for sha256:f86afbf779d83cf5aa2cc8377ea0b9f1cea140de22e1189270634d3a8ca4cf0e
Image is up to date for sha256:f86afbf779d83cf5aa2cc8377ea0b9f1cea140de22e1189270634d3a8ca4cf0e
Image is up to date for sha256:f86afbf779d83cf5aa2cc8377ea0b9f1cea140de22e1189270634d3a8ca4cf0e
Image is up to date for sha256:f86afbf779d83cf5aa2cc8377ea0b9f1cea140de22e1189270634d3a8ca4cf0e
Image is up to date for sha256:f86afbf779d83cf5aa2cc8377ea0b9f1cea140de22e1189270634d3a8ca4cf0e
69.4417718
69.2987744
69.1677747
69.0297754
68.8907764
68.7397799
68.5937793
68.4547814
68.3187812
68.1597841

Signed-off-by: Daniel Canter <dcanter@microsoft.com>