### PR TITLE
Cherry-pick snapshotter cleanup and panic log changes

### DIFF
--- a/pkg/ioutil/ioutil.go
+++ b/pkg/ioutil/ioutil.go
@@ -1,0 +1,45 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package ioutil
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+// LimitedRead reads at max `readLimitBytes` bytes from the file at path `filePath`. If the file has
+// more than `readLimitBytes` bytes of data then first `readLimitBytes` will be returned.
+func LimitedRead(filePath string, readLimitBytes int64) ([]byte, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, errors.Wrap(err, "limited read failed to open file")
+	}
+	defer f.Close()
+	if fi, err := f.Stat(); err == nil {
+		if fi.Size() < readLimitBytes {
+			readLimitBytes = fi.Size()
+		}
+		buf := make([]byte, readLimitBytes)
+		_, err := f.Read(buf)
+		if err != nil {
+			return []byte{}, errors.Wrap(err, "limited read failed during file read")
+		}
+		return buf, nil
+	}
+	return []byte{}, errors.Wrap(err, "limited read failed during file stat")
+}

--- a/runtime/v2/binary.go
+++ b/runtime/v2/binary.go
@@ -167,7 +167,7 @@ func (b *binary) Delete(ctx context.Context) (*runtime.Exit, error) {
 	if err := response.Unmarshal(out.Bytes()); err != nil {
 		return nil, err
 	}
-	if err := b.bundle.Delete(); err != nil {
+	if err := b.bundle.Delete(ctx); err != nil {
 		return nil, err
 	}
 	return &runtime.Exit{

--- a/runtime/v2/manager.go
+++ b/runtime/v2/manager.go
@@ -127,7 +127,7 @@ func (m *TaskManager) Create(ctx context.Context, id string, opts runtime.Create
 	}
 	defer func() {
 		if err != nil {
-			bundle.Delete()
+			bundle.Delete(ctx)
 		}
 	}()
 	topts := opts.TaskOptions
@@ -242,12 +242,12 @@ func (m *TaskManager) loadTasks(ctx context.Context) error {
 		// fast path
 		bf, err := ioutil.ReadDir(bundle.Path)
 		if err != nil {
-			bundle.Delete()
+			bundle.Delete(ctx)
 			log.G(ctx).WithError(err).Errorf("fast path read bundle path for %s", bundle.Path)
 			continue
 		}
 		if len(bf) == 0 {
-			bundle.Delete()
+			bundle.Delete(ctx)
 			continue
 		}
 		container, err := m.container(ctx, id)
@@ -256,7 +256,7 @@ func (m *TaskManager) loadTasks(ctx context.Context) error {
 			if err := mount.UnmountAll(filepath.Join(bundle.Path, "rootfs"), 0); err != nil {
 				log.G(ctx).WithError(err).Errorf("forceful unmount of rootfs %s", id)
 			}
-			bundle.Delete()
+			bundle.Delete(ctx)
 			continue
 		}
 		binaryCall := shimBinary(ctx, bundle, container.Runtime.Name, m.containerdAddress, m.containerdTTRPCAddress, m.events, m.tasks)

--- a/runtime/v2/shim.go
+++ b/runtime/v2/shim.go
@@ -249,7 +249,7 @@ func (s *shim) Delete(ctx context.Context) (*runtime.Exit, error) {
 	// remove self from the runtime task list
 	// this seems dirty but it cleans up the API across runtimes, tasks, and the service
 	s.rtTasks.Delete(ctx, s.ID())
-	if err := s.bundle.Delete(); err != nil {
+	if err := s.bundle.Delete(ctx); err != nil {
 		log.G(ctx).WithField("id", s.ID()).WithError(err).Error("failed to delete bundle")
 	}
 	if shimErr != nil {

--- a/snapshots/lcow/lcow.go
+++ b/snapshots/lcow/lcow.go
@@ -229,7 +229,14 @@ func (s *snapshotter) Remove(ctx context.Context, key string) error {
 	path := s.getSnapshotDir(id)
 	renamed := s.getSnapshotDir("rm-" + id)
 	if err := os.Rename(path, renamed); err != nil && !os.IsNotExist(err) {
-		return err
+		// Sometimes if there are some open handles to the files (especially VHD)
+		// inside the snapshot directory the rename call will return "access
+		// denied" or "file is being used by another process" errors.  Just
+		// returning that error causes the entire snapshot garbage collection
+		// operation to fail. To avoid that we return failed pre-condition error
+		// here so that snapshot garbage collection can continue and can cleanup
+		// other snapshots.
+		return errors.Wrap(errdefs.ErrFailedPrecondition, err.Error())
 	}
 
 	if err := t.Commit(); err != nil {


### PR DESCRIPTION
The Snapshotter cleanup fix and shim panic log changes should have ideally been merged into fork/master and then backported to fork/release/1.4. However, they were merged to fork/release/1.4 directly. This PR cherry-picks those commits back into fork/master.