### PR TITLE
Cherry-pick LCOW snapshotter changes to fork/master

### DIFF
--- a/rootfs/apply.go
+++ b/rootfs/apply.go
@@ -123,7 +123,7 @@ func applyLayers(ctx context.Context, layers []Layer, chain []digest.Digest, sn 
 	)
 
 	for {
-		key = fmt.Sprintf("extract-%s %s", uniquePart(), chainID)
+		key = fmt.Sprintf(snapshots.UnpackKeyFormat, uniquePart(), chainID)
 
 		// Prepare snapshot with from parent, label as root
 		mounts, err = sn.Prepare(ctx, key, parent.String(), opts...)

--- a/snapshots/lcow/lcow.go
+++ b/snapshots/lcow/lcow.go
@@ -337,40 +337,44 @@ func (s *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 		for _, o := range opts {
 			o(&snapshotInfo)
 		}
-
-		var sizeGB int
-		if sizeGBstr, ok := snapshotInfo.Labels[rootfsSizeLabel]; ok {
-			i32, err := strconv.ParseInt(sizeGBstr, 10, 32)
-			if err != nil {
-				return nil, errors.Wrapf(err, "failed to parse annotation %q=%q", rootfsSizeLabel, sizeGBstr)
-			}
-			sizeGB = int(i32)
-		}
-
-		var scratchLocation string
-		scratchLocation, _ = snapshotInfo.Labels[rootfsLocLabel]
-
-		scratchSource, err := s.openOrCreateScratch(ctx, sizeGB, scratchLocation)
-		if err != nil {
-			return nil, err
-		}
-		defer scratchSource.Close()
-
-		// TODO: JTERRY75 - This has to be called sandbox.vhdx for the time
-		// being but it really is the scratch.vhdx. Using this naming convention
-		// for now but this is not the kubernetes sandbox.
+		// IO/disk space optimization
 		//
-		// Create the sandbox.vhdx for this snapshot from the cache.
-		destPath := filepath.Join(snDir, "sandbox.vhdx")
-		dest, err := os.OpenFile(destPath, os.O_RDWR|os.O_CREATE, 0700)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to create sandbox.vhdx in snapshot")
-		}
-		defer dest.Close()
-		if _, err := io.Copy(dest, scratchSource); err != nil {
-			dest.Close()
-			os.Remove(destPath)
-			return nil, errors.Wrap(err, "failed to copy cached scratch.vhdx to sandbox.vhdx in snapshot")
+		// We only need one sandbox.vhd for the container. Skip making one for this
+		// snapshot if this isn't the snapshot that just houses the final sandbox.vhd
+		// that will be mounted as the containers scratch. Currently the key for a snapshot
+		// where a layer.vhd will be extracted to it will have the string `extract-` in it.
+		// If this is changed this will also need to be changed.
+		//
+		// We save about 17MB per layer (if the default scratch vhd size of 20GB is used) and of
+		// course the time to copy the vhd per snapshot.
+		if !strings.Contains(key, snapshots.UnpackKeyPrefix) {
+			var sizeGB int
+			if sizeGBstr, ok := snapshotInfo.Labels[rootfsSizeLabel]; ok {
+				i32, err := strconv.ParseInt(sizeGBstr, 10, 32)
+				if err != nil {
+					return nil, errors.Wrapf(err, "failed to parse label %q=%q", rootfsSizeLabel, sizeGBstr)
+				}
+				sizeGB = int(i32)
+			}
+
+			scratchSource, err := s.openOrCreateScratch(ctx, sizeGB, "")
+			if err != nil {
+				return nil, err
+			}
+			defer scratchSource.Close()
+
+			// Create the sandbox.vhdx for this snapshot from the cache.
+			destPath := filepath.Join(snDir, "sandbox.vhdx")
+			dest, err := os.OpenFile(destPath, os.O_RDWR|os.O_CREATE, 0700)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to create sandbox.vhdx in snapshot")
+			}
+			defer dest.Close()
+			if _, err := io.Copy(dest, scratchSource); err != nil {
+				dest.Close()
+				os.Remove(destPath)
+				return nil, errors.Wrap(err, "failed to copy cached scratch.vhdx to sandbox.vhdx in snapshot")
+			}
 		}
 	}
 

--- a/snapshots/lcow/lcow.go
+++ b/snapshots/lcow/lcow.go
@@ -58,8 +58,10 @@ func init() {
 }
 
 const (
-	rootfsSizeLabel = "containerd.io/snapshot/io.microsoft.container.storage.rootfs.size-gb"
-	rootfsLocLabel  = "containerd.io/snapshot/io.microsoft.container.storage.rootfs.location"
+	rootfsSizeLabel           = "containerd.io/snapshot/io.microsoft.container.storage.rootfs.size-gb"
+	rootfsLocLabel            = "containerd.io/snapshot/io.microsoft.container.storage.rootfs.location"
+	reuseScratchLabel         = "containerd.io/snapshot/io.microsoft.container.storage.reuse-scratch"
+	reuseScratchOwnerKeyLabel = "containerd.io/snapshot/io.microsoft.owner.key"
 )
 
 type snapshotter struct {
@@ -313,7 +315,7 @@ func (s *snapshotter) getSnapshotDir(id string) string {
 	return filepath.Join(s.root, "snapshots", id)
 }
 
-func (s *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, key, parent string, opts []snapshots.Opt) ([]mount.Mount, error) {
+func (s *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, key, parent string, opts []snapshots.Opt) (_ []mount.Mount, err error) {
 	ctx, t, err := s.ms.TransactionContext(ctx, true)
 	if err != nil {
 		return nil, err
@@ -337,43 +339,65 @@ func (s *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 		for _, o := range opts {
 			o(&snapshotInfo)
 		}
+
+		defer func() {
+			if err != nil {
+				os.RemoveAll(snDir)
+			}
+		}()
+
 		// IO/disk space optimization
 		//
 		// We only need one sandbox.vhd for the container. Skip making one for this
 		// snapshot if this isn't the snapshot that just houses the final sandbox.vhd
-		// that will be mounted as the containers scratch. Currently the key for a snapshot
-		// where a layer.vhd will be extracted to it will have the string `extract-` in it.
+		// that will be mounted as the containers scratch. The key for a snapshot
+		// where a layer.vhd will be extracted to it will have the substring `extract-` in it.
 		// If this is changed this will also need to be changed.
 		//
 		// We save about 17MB per layer (if the default scratch vhd size of 20GB is used) and of
-		// course the time to copy the vhd per snapshot.
+		// course the time to copy the vhdx per snapshot.
 		if !strings.Contains(key, snapshots.UnpackKeyPrefix) {
-			var sizeGB int
-			if sizeGBstr, ok := snapshotInfo.Labels[rootfsSizeLabel]; ok {
-				i32, err := strconv.ParseInt(sizeGBstr, 10, 32)
-				if err != nil {
-					return nil, errors.Wrapf(err, "failed to parse label %q=%q", rootfsSizeLabel, sizeGBstr)
+			// This is the code path that handles re-using a scratch disk that has already been
+			// made/mounted for an LCOW UVM. In the non sharing case, we create a new disk and mount this
+			// into the LCOW UVM for every container but there are certain scenarios where we'd rather
+			// just mount a single disk and then have every container share this one storage space instead of
+			// every container having it's own xGB of space to play around with.
+			//
+			// This is accomplished by just making a symlink to the disk that we'd like to share and then
+			// using ref counting later on down the stack in hcsshim if we see that we've already mounted this
+			// disk.
+			shareScratch := snapshotInfo.Labels[reuseScratchLabel]
+			ownerKey := snapshotInfo.Labels[reuseScratchOwnerKeyLabel]
+			if shareScratch == "true" && ownerKey != "" {
+				if err = s.handleSharing(ctx, ownerKey, snDir); err != nil {
+					return nil, err
 				}
-				sizeGB = int(i32)
-			}
+			} else {
+				var sizeGB int
+				if sizeGBstr, ok := snapshotInfo.Labels[rootfsSizeLabel]; ok {
+					i64, _ := strconv.ParseInt(sizeGBstr, 10, 32)
+					sizeGB = int(i64)
+				}
 
-			scratchSource, err := s.openOrCreateScratch(ctx, sizeGB, "")
-			if err != nil {
-				return nil, err
-			}
-			defer scratchSource.Close()
+				scratchLocation := snapshotInfo.Labels[rootfsLocLabel]
+				scratchSource, err := s.openOrCreateScratch(ctx, sizeGB, scratchLocation)
+				if err != nil {
+					return nil, err
+				}
+				defer scratchSource.Close()
 
-			// Create the sandbox.vhdx for this snapshot from the cache.
-			destPath := filepath.Join(snDir, "sandbox.vhdx")
-			dest, err := os.OpenFile(destPath, os.O_RDWR|os.O_CREATE, 0700)
-			if err != nil {
-				return nil, errors.Wrap(err, "failed to create sandbox.vhdx in snapshot")
-			}
-			defer dest.Close()
-			if _, err := io.Copy(dest, scratchSource); err != nil {
-				dest.Close()
-				os.Remove(destPath)
-				return nil, errors.Wrap(err, "failed to copy cached scratch.vhdx to sandbox.vhdx in snapshot")
+				// Create the sandbox.vhdx for this snapshot from the cache
+				destPath := filepath.Join(snDir, "sandbox.vhdx")
+				dest, err := os.OpenFile(destPath, os.O_RDWR|os.O_CREATE, 0700)
+				if err != nil {
+					return nil, errors.Wrap(err, "failed to create sandbox.vhdx in snapshot")
+				}
+				defer dest.Close()
+				if _, err := io.Copy(dest, scratchSource); err != nil {
+					dest.Close()
+					os.Remove(destPath)
+					return nil, errors.Wrap(err, "failed to copy cached scratch.vhdx to sandbox.vhdx in snapshot")
+				}
 			}
 		}
 	}
@@ -385,8 +409,38 @@ func (s *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 	return s.mounts(newSnapshot), nil
 }
 
+func (s *snapshotter) handleSharing(ctx context.Context, id, snDir string) error {
+	var key string
+	if err := s.Walk(ctx, func(ctx context.Context, info snapshots.Info) error {
+		if strings.Contains(info.Name, id) {
+			key = info.Name
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	mounts, err := s.Mounts(ctx, key)
+	if err != nil {
+		return errors.Wrap(err, "failed to get mounts for owner snapshot")
+	}
+
+	sandboxPath := filepath.Join(mounts[0].Source, "sandbox.vhdx")
+	linkPath := filepath.Join(snDir, "sandbox.vhdx")
+	if _, err := os.Stat(sandboxPath); err != nil {
+		return errors.Wrap(err, "failed to find sandbox.vhdx in snapshot directory")
+	}
+
+	// We've found everything we need, now just make a symlink in our new snapshot to the
+	// sandbox.vhdx in the scratch we're asking to share.
+	if err := os.Symlink(sandboxPath, linkPath); err != nil {
+		return errors.Wrap(err, "failed to create symlink for sandbox scratch space")
+	}
+	return nil
+}
+
 func (s *snapshotter) openOrCreateScratch(ctx context.Context, sizeGB int, scratchLoc string) (_ *os.File, err error) {
-	// Create the scratch.vhdx cache file if it doesn't already exist.
+	// Create the scratch.vhdx cache file if it doesn't already exit.
 	s.scratchLock.Lock()
 	defer s.scratchLock.Unlock()
 
@@ -406,7 +460,7 @@ func (s *snapshotter) openOrCreateScratch(ctx context.Context, sizeGB int, scrat
 			return nil, errors.Wrapf(err, "failed to open vhd %s for read", vhdFileName)
 		}
 
-		log.G(ctx).Debugf("vhd %s not found, creating a new one", vhdFileName)
+		log.G(ctx).Debugf("vhdx %s not found, creating a new one", vhdFileName)
 
 		// Golang logic for ioutil.TempFile without the file creation
 		r := uint32(time.Now().UnixNano() + int64(os.Getpid()))
@@ -428,16 +482,16 @@ func (s *snapshotter) openOrCreateScratch(ctx context.Context, sizeGB int, scrat
 		}
 
 		if err := rhcs.CreateScratchWithOpts(ctx, scratchTempPath, &opt); err != nil {
-			_ = os.Remove(scratchTempPath)
+			os.Remove(scratchTempPath)
 			return nil, errors.Wrapf(err, "failed to create '%s' temp file", scratchTempName)
 		}
 		if err := os.Rename(scratchTempPath, scratchFinalPath); err != nil {
-			_ = os.Remove(scratchTempPath)
+			os.Remove(scratchTempPath)
 			return nil, errors.Wrapf(err, "failed to rename '%s' temp file to 'scratch.vhdx'", scratchTempName)
 		}
 		scratchSource, err = os.OpenFile(scratchFinalPath, os.O_RDONLY, 0700)
 		if err != nil {
-			_ = os.Remove(scratchFinalPath)
+			os.Remove(scratchFinalPath)
 			return nil, errors.Wrap(err, "failed to open scratch.vhdx for read after creation")
 		}
 	} else {

--- a/snapshots/snapshotter.go
+++ b/snapshots/snapshotter.go
@@ -26,6 +26,10 @@ import (
 )
 
 const (
+	// UnpackKeyPrefix is the beginning of the key format used for snapshots that will have
+	// image content unpacked into them.
+	UnpackKeyPrefix       = "extract"
+	UnpackKeyFormat       = UnpackKeyPrefix + "-%s %s"
 	inheritedLabelsPrefix = "containerd.io/snapshot/"
 	labelSnapshotRef      = "containerd.io/snapshot.ref"
 )

--- a/snapshots/windows/windows.go
+++ b/snapshots/windows/windows.go
@@ -334,35 +334,50 @@ func (s *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 	}
 
 	if kind == snapshots.KindActive {
-		parentLayerPaths := s.parentIDsToParentPaths(newSnapshot.ParentIDs)
-
-		var parentPath string
-		if len(parentLayerPaths) != 0 {
-			parentPath = parentLayerPaths[0]
+		log.G(ctx).Debug("createSnapshot active")
+		// Create the new snapshot dir
+		snDir := s.getSnapshotDir(newSnapshot.ID)
+		if err := os.MkdirAll(snDir, 0700); err != nil {
+			return nil, err
 		}
 
-		if err := hcsshim.CreateSandboxLayer(s.info, newSnapshot.ID, parentPath, parentLayerPaths); err != nil {
-			return nil, errors.Wrap(err, "failed to create sandbox layer")
-		}
+		// IO/disk space optimization
+		//
+		// We only need one sandbox.vhdx for the container. Skip making one for this
+		// snapshot if this isn't the snapshot that just houses the final sandbox.vhd
+		// that will be mounted as the containers scratch. Currently the key for a snapshot
+		// where a layer will be extracted to will have the string `extract-` in it.
+		if !strings.Contains(key, snapshots.UnpackKeyPrefix) {
+			parentLayerPaths := s.parentIDsToParentPaths(newSnapshot.ParentIDs)
 
-		var snapshotInfo snapshots.Info
-		for _, o := range opts {
-			o(&snapshotInfo)
-		}
-
-		var sizeGB int
-		if sizeGBstr, ok := snapshotInfo.Labels[rootfsSizeLabel]; ok {
-			i32, err := strconv.ParseInt(sizeGBstr, 10, 32)
-			if err != nil {
-				return nil, errors.Wrapf(err, "failed to parse annotation %q=%q", rootfsSizeLabel, sizeGBstr)
+			var parentPath string
+			if len(parentLayerPaths) != 0 {
+				parentPath = parentLayerPaths[0]
 			}
-			sizeGB = int(i32)
-		}
 
-		if sizeGB > 0 {
-			const gbToByte = 1024 * 1024 * 1024
-			if err := hcsshim.ExpandSandboxSize(s.info, newSnapshot.ID, uint64(gbToByte*sizeGB)); err != nil {
-				return nil, errors.Wrapf(err, "failed to expand scratch size to %d GB", sizeGB)
+			if err := hcsshim.CreateSandboxLayer(s.info, newSnapshot.ID, parentPath, parentLayerPaths); err != nil {
+				return nil, errors.Wrap(err, "failed to create sandbox layer")
+			}
+
+			var snapshotInfo snapshots.Info
+			for _, o := range opts {
+				o(&snapshotInfo)
+			}
+
+			var sizeGB int
+			if sizeGBstr, ok := snapshotInfo.Labels[rootfsSizeLabel]; ok {
+				i32, err := strconv.ParseInt(sizeGBstr, 10, 32)
+				if err != nil {
+					return nil, errors.Wrapf(err, "failed to parse label %q=%q", rootfsSizeLabel, sizeGBstr)
+				}
+				sizeGB = int(i32)
+			}
+
+			if sizeGB > 0 {
+				const gbToByte = 1024 * 1024 * 1024
+				if err := hcsshim.ExpandSandboxSize(s.info, newSnapshot.ID, uint64(gbToByte*sizeGB)); err != nil {
+					return nil, errors.Wrapf(err, "failed to expand scratch size to %d GB", sizeGB)
+				}
 			}
 		}
 	}

--- a/unpacker.go
+++ b/unpacker.go
@@ -138,7 +138,7 @@ EachLayer:
 
 		for try := 1; try <= 3; try++ {
 			// Prepare snapshot with from parent, label as root
-			key = fmt.Sprintf("extract-%s %s", uniquePart(), chainID)
+			key = fmt.Sprintf(snapshots.UnpackKeyFormat, uniquePart(), chainID)
 			mounts, err = sn.Prepare(ctx, key, parent.String(), opts...)
 			if err != nil {
 				if errdefs.IsAlreadyExists(err) {


### PR DESCRIPTION
This brings in the two commits that were missing from fork/master that are in fork/release/1.4. I was going to just merge in 
upstream main as it contains these commits, but there's a couple annoyances with some commits we have in here. @katiewasnothere will be looking into remedying this as I'm not sure what direction is best for the offending commits. 