### PR TITLE
Improve errors logs for snapshotter errors

### DIFF
--- a/snapshots/windows/common.go
+++ b/snapshots/windows/common.go
@@ -177,7 +177,7 @@ func (s *windowsSnapshotterBase) Commit(ctx context.Context, name, key string, o
 	}
 
 	if _, err = storage.CommitActive(ctx, key, name, snapshots.Usage(usage), opts...); err != nil {
-		return errors.Wrap(err, "failed to commit snapshot")
+		return errors.Wrapf(err, "failed to commit snapshot %s", id)
 	}
 	return t.Commit()
 }
@@ -277,16 +277,17 @@ func onErrorDirectoryCleanup(ctx context.Context, err *error, dirPaths ...string
 func (s *windowsSnapshotterBase) createSnapshotCommon(ctx context.Context, kind snapshots.Kind, key, parent string, opts []snapshots.Opt) (_ storage.Snapshot, _ snapshots.Info, err error) {
 	newSnapshot, err := storage.CreateSnapshot(ctx, kind, key, parent, opts...)
 	if err != nil {
-		return storage.Snapshot{}, snapshots.Info{}, errors.Wrap(err, "failed to create snapshot")
+		return storage.Snapshot{}, snapshots.Info{}, errors.Wrapf(err, "failed to create snapshot with key %s", key)
 	}
 
+	log.G(ctx).Debug("creating new snapshot for key %s, %+v", key, newSnapshot)
 	// The snapshot scratch override location could be specified in the containerd.toml or it could
 	// be specified in the container config. The one specified in the container config takes preference.
 	// Get the correct override location, update that in the snapshot snapshotInfo and save it so that all other
 	// operations will use the correct path.
 	_, snapshotInfo, _, err := storage.GetInfo(ctx, key)
 	if err != nil {
-		return storage.Snapshot{}, snapshots.Info{}, errors.Wrap(err, "failed to get snapshot info")
+		return storage.Snapshot{}, snapshots.Info{}, errors.Wrapf(err, "failed to get snapshot info for key %s", key)
 	}
 
 	_, ok := snapshotInfo.Labels[labelScratchSnapshotLocation]
@@ -299,18 +300,16 @@ func (s *windowsSnapshotterBase) createSnapshotCommon(ctx context.Context, kind 
 			snapshotInfo.Labels[labelScratchSnapshotLocation] = s.snConfig.SnapshotterScratchLocation
 			snapshotInfo, err = storage.UpdateInfo(ctx, snapshotInfo)
 			if err != nil {
-				errors.Wrap(err, "failed to write updated info")
+				errors.Wrapf(err, "failed to write updated info for snapshot key %s", key)
 			}
 		}
 	}
 
 	if kind == snapshots.KindActive {
-		log.G(ctx).Debug("createSnapshot active")
-
 		// Create the new snapshot dir
 		_, _, err := s.createSnapshotDirectory(ctx, snapshotInfo, key, newSnapshot.ID)
 		if err != nil {
-			return storage.Snapshot{}, snapshots.Info{}, errors.Wrap(err, "failed to create snapshot directory")
+			return storage.Snapshot{}, snapshots.Info{}, errors.Wrapf(err, "failed to create snapshot directory for snapshot key %s", key)
 		}
 	}
 

--- a/snapshots/windows/lcow.go
+++ b/snapshots/windows/lcow.go
@@ -84,7 +84,7 @@ func (l *lcowSnapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount
 
 	snapshot, err := storage.GetSnapshot(ctx, key)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get snapshot mount")
+		return nil, errors.Wrapf(err, "failed to get snapshot mount for key %s", key)
 	}
 	m := l.lcowMounts(snapshot)
 	return m, nil
@@ -101,12 +101,12 @@ func (l *lcowSnapshotter) Remove(ctx context.Context, key string) error {
 
 	id, snInfo, _, err := storage.GetInfo(ctx, key)
 	if err != nil {
-		return errors.Wrapf(errdefs.ErrFailedPrecondition, "failed to get snapshot info: %s", err)
+		return errors.Wrapf(errdefs.ErrFailedPrecondition, "failed to get snapshot info for key %s: %s", key, err)
 	}
 
 	_, _, err = storage.Remove(ctx, key)
 	if err != nil {
-		return errors.Wrap(err, "failed to remove")
+		return errors.Wrapf(err, "failed to remove snapshot %s", id)
 	}
 
 	path := l.getSnapshotDir(id)
@@ -128,7 +128,7 @@ func (l *lcowSnapshotter) Remove(ctx context.Context, key string) error {
 			// May cause inconsistent data on disk
 			log.G(ctx).WithError(err1).WithField("path", renamed).Errorf("Failed to rename after failed commit")
 		}
-		return errors.Wrap(err, "failed to commit")
+		return errors.Wrapf(err, "failed to commit removal of snapshot %s", id)
 	}
 
 	if path != overridePath {
@@ -202,20 +202,20 @@ func (l *lcowSnapshotter) createSnapshot(ctx context.Context, kind snapshots.Kin
 				destPath := filepath.Join(snDir, "sandbox.vhdx")
 				dest, err := os.OpenFile(destPath, os.O_RDWR|os.O_CREATE, 0700)
 				if err != nil {
-					return nil, errors.Wrap(err, "failed to create sandbox.vhdx in snapshot")
+					return nil, errors.Wrapf(err, "failed to create sandbox.vhdx for snapshot key %s", key)
 				}
 				defer dest.Close()
 				if _, err := io.Copy(dest, scratchSource); err != nil {
 					dest.Close()
 					os.Remove(destPath)
-					return nil, errors.Wrap(err, "failed to copy cached scratch.vhdx to sandbox.vhdx in snapshot")
+					return nil, errors.Wrapf(err, "failed to copy cached scratch.vhdx to sandbox.vhdx for snapshot key %s", key)
 				}
 			}
 		}
 	}
 
 	if err := t.Commit(); err != nil {
-		return nil, errors.Wrap(err, "commit failed")
+		return nil, errors.Wrapf(err, "create snapshot tx commit failed for snapshot key %s", key)
 	}
 
 	return l.lcowMounts(newSnapshot), nil
@@ -234,13 +234,13 @@ func (l *lcowSnapshotter) handleSharing(ctx context.Context, id, snDir string) e
 
 	mounts, err := l.Mounts(ctx, key)
 	if err != nil {
-		return errors.Wrap(err, "failed to get mounts for owner snapshot")
+		return errors.Wrapf(err, "failed to get mounts for owner snapshot (id %s)", id)
 	}
 
 	sandboxPath := filepath.Join(mounts[0].Source, "sandbox.vhdx")
 	linkPath := filepath.Join(snDir, "sandbox.vhdx")
 	if _, err := os.Stat(sandboxPath); err != nil {
-		return errors.Wrap(err, "failed to find sandbox.vhdx in snapshot directory")
+		return errors.Wrapf(err, "failed to find sandbox.vhdx in snapshot directory %s", mounts[0].Source)
 	}
 
 	// We've found everything we need, now just make a symlink in our new snapshot to the
@@ -301,7 +301,7 @@ func (l *lcowSnapshotter) openOrCreateScratch(ctx context.Context, sizeGB int) (
 		scratchSource, err = os.OpenFile(scratchFinalPath, os.O_RDONLY, 0700)
 		if err != nil {
 			os.Remove(scratchFinalPath)
-			return nil, errors.Wrap(err, "failed to open scratch.vhdx for read after creation")
+			return nil, errors.Wrapf(err, "failed to open scratch.vhdx at %s for read after creation", scratchFinalPath)
 		}
 	} else {
 		log.G(ctx).Debugf("scratch vhd %s was already present. Retrieved from cache", vhdFileName)

--- a/snapshots/windows/wcow.go
+++ b/snapshots/windows/wcow.go
@@ -84,7 +84,7 @@ func (w *wcowSnapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount
 
 	snapshot, err := storage.GetSnapshot(ctx, key)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get snapshot mount")
+		return nil, errors.Wrapf(err, "failed to get snapshot mounts for key %s", key)
 	}
 	return w.wcowMounts(snapshot), nil
 }
@@ -100,12 +100,12 @@ func (w *wcowSnapshotter) Remove(ctx context.Context, key string) error {
 
 	id, snInfo, _, err := storage.GetInfo(ctx, key)
 	if err != nil {
-		return errors.Wrapf(errdefs.ErrFailedPrecondition, "failed to get snapshot info: %s", err)
+		return errors.Wrapf(errdefs.ErrFailedPrecondition, "failed to get info for snapshot key %s: %s", key, err)
 	}
 
 	_, _, err = storage.Remove(ctx, key)
 	if err != nil {
-		return errors.Wrap(err, "failed to remove")
+		return errors.Wrapf(err, "failed to remove snapshot with key %s", key)
 	}
 
 	path := w.getSnapshotDir(id)
@@ -129,7 +129,7 @@ func (w *wcowSnapshotter) Remove(ctx context.Context, key string) error {
 
 			}
 			if rerr := os.Rename(path, renamed); rerr != nil {
-				return errors.Wrapf(errdefs.ErrFailedPrecondition, "second rename attempt failed for snapshot %s with error %s", id, rerr)
+				return errors.Wrapf(errdefs.ErrFailedPrecondition, "second rename attempt failed for snapshot with error %s", rerr)
 			}
 		} else {
 			return errors.Wrap(errdefs.ErrFailedPrecondition, err.Error())
@@ -142,7 +142,7 @@ func (w *wcowSnapshotter) Remove(ctx context.Context, key string) error {
 			// May cause inconsistent data on disk
 			log.G(ctx).WithError(err1).Errorf("failed to undo rename after failed commit")
 		}
-		return errors.Wrap(err, "failed to commit")
+		return errors.Wrapf(err, "failed to commit removal of snapshot %s", id)
 	}
 
 	drInfo := w.info
@@ -192,7 +192,7 @@ func (w *wcowSnapshotter) createSnapshot(ctx context.Context, kind snapshots.Kin
 			}
 
 			if err := hcsshim.CreateSandboxLayer(w.info, newSnapshot.ID, parentPath, parentLayerPaths); err != nil {
-				return nil, errors.Wrap(err, "failed to create sandbox layer")
+				return nil, errors.Wrapf(err, "failed to create sandbox layer for snapshot key %s", key)
 			}
 
 			var sizeGB int
@@ -207,14 +207,14 @@ func (w *wcowSnapshotter) createSnapshot(ctx context.Context, kind snapshots.Kin
 			if sizeGB > 0 {
 				const gbToByte = 1024 * 1024 * 1024
 				if err := hcsshim.ExpandSandboxSize(w.info, newSnapshot.ID, uint64(gbToByte*sizeGB)); err != nil {
-					return nil, errors.Wrapf(err, "failed to expand scratch size to %d GB", sizeGB)
+					return nil, errors.Wrapf(err, "failed to expand scratch size to %d GB for snapshot key %s", sizeGB, key)
 				}
 			}
 		}
 	}
 
 	if err := t.Commit(); err != nil {
-		return nil, errors.Wrap(err, "commit failed")
+		return nil, errors.Wrapf(err, "creation snapshot tx commit failed for snapshot key %s", key)
 	}
 
 	return w.wcowMounts(newSnapshot), nil


### PR DESCRIPTION
Most of the snapshotter errors don't include snapshot ID or snapshot key in the errors
string. This makes it difficult to associate a snapshot with its UVM or container. This
commit updates those errors to include snapshot key or ID so that it helps in debugging.

Signed-off-by: Amit Barve <ambarve@microsoft.com>