### PR TITLE
Added retry to bundle deletion

### DIFF
--- a/runtime/v2/bundle.go
+++ b/runtime/v2/bundle.go
@@ -18,7 +18,6 @@ package v2
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -160,17 +159,4 @@ func (b *Bundle) Delete(ctx context.Context) error {
 		}
 	}
 	return errors.Wrapf(err, "failed to remove both bundle and workdir locations: %v", err2)
-}
-
-// atomicDelete renames the path to a hidden file before removal
-func atomicDelete(path string) error {
-	// create a hidden dir for an atomic removal
-	atomicPath := filepath.Join(filepath.Dir(path), fmt.Sprintf(".%s", filepath.Base(path)))
-	if err := os.Rename(path, atomicPath); err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-	return os.RemoveAll(atomicPath)
 }

--- a/runtime/v2/bundle_unix.go
+++ b/runtime/v2/bundle_unix.go
@@ -1,0 +1,39 @@
+//go:build !windows
+// +build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package v2
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// atomicDelete renames the path to a hidden file before removal
+func atomicDelete(path string) error {
+	// create a hidden dir for an atomic removal
+	atomicPath := filepath.Join(filepath.Dir(path), fmt.Sprintf(".%s", filepath.Base(path)))
+	if err := os.Rename(path, atomicPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	return os.RemoveAll(atomicPath)
+}

--- a/runtime/v2/bundle_windows.go
+++ b/runtime/v2/bundle_windows.go
@@ -1,0 +1,59 @@
+//go:build windows
+// +build windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package v2
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows"
+)
+
+const nRetries = 3
+const retryWait = 100 * time.Millisecond
+
+// atomicDelete renames the path to a hidden file before removal
+func atomicDelete(path string) error {
+	// create a hidden dir for an atomic removal
+	atomicPath := filepath.Join(filepath.Dir(path), fmt.Sprintf(".%s", filepath.Base(path)))
+	// Windows places a lock on a process's working directory, so, unlike Linux, you cannot delete
+	// if the process is still running.
+	// Add retries with wait to allow the shim to fully exit.
+	var err error
+	for i := 1; i <= nRetries; i++ {
+		if err = os.Rename(path, atomicPath); err != nil {
+			logrus.Debugf("bundle %q atomic delete attempt #%d failed: %v", path, i, err)
+			if os.IsNotExist(err) {
+				return nil
+			}
+			if i != nRetries && errors.Is(err, windows.ERROR_SHARING_VIOLATION) {
+				time.Sleep(retryWait)
+				continue
+			}
+			return err
+		}
+		break
+	}
+	return os.RemoveAll(atomicPath)
+}


### PR DESCRIPTION
Added retries after waits to allow shim process to fully close and free up on bundle directory, since the bundle path is the shim's working directory.

Without this, containerd fails to delete the shim erroring with: `The process cannot access the file because it is being used by another process.`

Signed-off-by: Hamza El-Saawy <hamzaelsaawy@microsoft.com>