### PR TITLE
Cherry pick LCOW layers integrity checking, skip unpack option, and log containerd's panic content

### DIFF
--- a/client.go
+++ b/client.go
@@ -371,6 +371,10 @@ type RemoteContext struct {
 	// AllMetadata downloads all manifests and known-configuration files
 	AllMetadata bool
 
+	// DisableSameLayerUnpack prevents a parallel unpack of the same image layer and will wait for the first
+	// in line to complete before either returning the error if there was one, or returning ErrAlreadyExists.
+	DisableSameLayerUnpack bool
+
 	// ChildLabelMap sets the labels used to reference child objects in the content
 	// store. By default, all GC reference labels will be set for all fetched content.
 	ChildLabelMap func(ocispec.Descriptor) []string

--- a/client_opts.go
+++ b/client_opts.go
@@ -252,3 +252,14 @@ func WithAllMetadata() RemoteOpt {
 		return nil
 	}
 }
+
+// WithDisableSameLayerUnpack sets the option that disallows Containerd from unpacking the same layer in parallel. This helps de-duplicate work
+// if pulling multiple images that share layers.
+func WithDisableSameLayerUnpack() RemoteOpt {
+	return func(client *Client, c *RemoteContext) error {
+		c.DisableSameLayerUnpack = true
+		c.SnapshotterOpts = append(c.SnapshotterOpts,
+			snapshots.WithLabels(map[string]string{"containerd.io/snapshot/disable-same-unpack": ""}))
+		return nil
+	}
+}

--- a/client_opts.go
+++ b/client_opts.go
@@ -19,6 +19,7 @@ package containerd
 import (
 	"time"
 
+	"github.com/containerd/containerd/diff"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/remotes"
@@ -183,6 +184,12 @@ func WithPullLabels(labels map[string]string) RemoteOpt {
 		}
 		return nil
 	}
+}
+
+// WithLCOWLayerIntegrity enables integrity protection of LCOW layers by setting appropriate
+// RemoteContext label
+func WithLCOWLayerIntegrity() RemoteOpt {
+	return WithPullLabel(diff.LCOWLayerIntegrityEnabled, "true")
 }
 
 // WithChildLabelMap sets the map function used to define the labels set

--- a/cmd/containerd/command/service_windows.go
+++ b/cmd/containerd/command/service_windows.go
@@ -17,6 +17,7 @@
 package command
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"log"
@@ -337,6 +338,9 @@ func initPanicFile(path string) error {
 	// and replace it.
 	if st.Size() > 0 {
 		panicFile.Close()
+
+		logFileInChunks(path)
+
 		os.Rename(path, path+".old")
 		panicFile, err = os.Create(path)
 		if err != nil {
@@ -378,4 +382,56 @@ func removePanicFile() {
 			os.Remove(panicFile.Name())
 		}
 	}
+}
+
+func logFileInChunks(path string) error {
+	fileReader, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer fileReader.Close()
+
+	st, err := fileReader.Stat()
+	if err != nil {
+		return err
+	}
+
+	if st.Size() == 0 {
+		return nil
+	}
+
+	// There seems to be a limit for the message length, which is somewhere between 16-32KB.
+	// Set the chunkSize to 16KB, which is the max power of 2 that seems to work.
+	chunkSize := 16 * 1024
+	numChunks := st.Size() / int64(chunkSize)
+	if st.Size()%int64(chunkSize) > 0 {
+		numChunks++
+	}
+	buf := make([]byte, chunkSize)
+
+	// Set reader size (buffer size) to 1MB to issue less reads.
+	readerSize := 1024 * 1024
+	reader := bufio.NewReaderSize(fileReader, readerSize)
+	logrus.WithFields(logrus.Fields{
+		"filename":   path,
+		"chunkCount": numChunks,
+	}).Debug("Begin logging file chunks")
+
+	indx := 0
+	for {
+		n, err := reader.Read(buf)
+		if err != nil {
+			if err != io.EOF {
+				logrus.WithError(err).Error("failed to read file chunks")
+			}
+			break
+		}
+		logrus.WithFields(logrus.Fields{
+			"index": indx,
+			"chunk": string(buf[:n]),
+		}).Debug("logging file chunk")
+		indx++
+	}
+	logrus.Debug("End logging file chunks")
+	return nil
 }

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -19,10 +19,18 @@ package diff
 import (
 	"context"
 	"io"
+	"strings"
 
 	"github.com/containerd/containerd/mount"
+	"github.com/containerd/typeurl"
 	"github.com/gogo/protobuf/types"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+const (
+	LabelPrefix               = "containerd.io/diff/"
+	LCOWLayerIntegrityEnabled = LabelPrefix + "io.microsoft.lcow.append-dm-verity"
 )
 
 // Config is used to hold parameters needed for a diff operation
@@ -119,4 +127,46 @@ func WithPayloads(payloads map[string]*types.Any) ApplyOpt {
 		c.ProcessorPayloads = payloads
 		return nil
 	}
+}
+
+// WithStringPayloads marshals string values as types.Any and
+// sets/updates processor payloads
+func WithStringPayloads(labels map[string]string) ApplyOpt {
+	return func(_ context.Context, _ ocispec.Descriptor, c *ApplyConfig) error {
+		if labels == nil {
+			return nil
+		}
+
+		if c.ProcessorPayloads == nil {
+			c.ProcessorPayloads = make(map[string]*types.Any)
+		}
+
+		for k, v := range labels {
+			msg := &types.StringValue{
+				Value: v,
+			}
+			any, err := typeurl.MarshalAny(msg)
+			if err != nil {
+				return errors.Wrap(err, "failed to marshal string")
+			}
+			c.ProcessorPayloads[k] = any
+		}
+		return nil
+	}
+}
+
+// FilterDiffLabels filters the provided labels by removing any key which
+// isn't a diff label. Diff labels have a prefix of "containerd.io/diff/"
+func FilterDiffLabels(labels map[string]string) map[string]string {
+	if labels == nil {
+		return nil
+	}
+
+	filtered := make(map[string]string)
+	for k, v := range labels {
+		if strings.HasPrefix(k, LabelPrefix) {
+			filtered[k] = v
+		}
+	}
+	return filtered
 }

--- a/diff/lcow/lcow.go
+++ b/diff/lcow/lcow.go
@@ -36,6 +36,8 @@ import (
 	"github.com/containerd/containerd/metadata"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/plugin"
+	"github.com/containerd/typeurl"
+	"github.com/gogo/protobuf/types"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -155,7 +157,24 @@ func (s windowsLcowDiff) Apply(ctx context.Context, desc ocispec.Descriptor, mou
 		}
 	}()
 
-	err = tar2ext4.Convert(rc, outFile, tar2ext4.ConvertWhiteout, tar2ext4.AppendVhdFooter, tar2ext4.MaximumDiskSize(maxLcowVhdSizeGB))
+	t2e4Opts := []tar2ext4.Option{
+		tar2ext4.ConvertWhiteout,
+		tar2ext4.AppendVhdFooter,
+		tar2ext4.MaximumDiskSize(maxLcowVhdSizeGB),
+	}
+	if config.ProcessorPayloads != nil {
+		if msg, ok := config.ProcessorPayloads[diff.LCOWLayerIntegrityEnabled]; ok {
+			val, err := typeurl.UnmarshalAny(msg)
+			if err != nil {
+				return emptyDesc, errors.Wrapf(err, "failed to unmarshal processor payloads")
+			}
+			if str, ok := val.(*types.StringValue); ok && str.Value == "true" {
+				t2e4Opts = append(t2e4Opts, tar2ext4.AppendDMVerity)
+			}
+		}
+	}
+
+	err = tar2ext4.Convert(rc, outFile, t2e4Opts...)
 	if err != nil {
 		return emptyDesc, errors.Wrapf(err, "failed to convert tar2ext4 vhd")
 	}

--- a/image.go
+++ b/image.go
@@ -300,6 +300,14 @@ func WithSnapshotterPlatformCheck() UnpackOpt {
 	}
 }
 
+// WithUnpackConfigApplyOpts sets ApplyOpts for UnpackConfig
+func WithUnpackConfigApplyOpts(opts ...diff.ApplyOpt) UnpackOpt {
+	return func(_ context.Context, uc *UnpackConfig) error {
+		uc.ApplyOpts = append(uc.ApplyOpts, opts...)
+		return nil
+	}
+}
+
 func (i *image) Unpack(ctx context.Context, snapshotterName string, opts ...UnpackOpt) error {
 	ctx, done, err := i.client.WithLease(ctx)
 	if err != nil {

--- a/metadata/snapshot.go
+++ b/metadata/snapshot.go
@@ -37,15 +37,77 @@ import (
 )
 
 const (
-	inheritedLabelsPrefix = "containerd.io/snapshot/"
-	labelSnapshotRef      = "containerd.io/snapshot.ref"
+	inheritedLabelsPrefix  = "containerd.io/snapshot/"
+	labelSnapshotRef       = "containerd.io/snapshot.ref"
+	labelDisableSameUnpack = "containerd.io/snapshot/disable-same-unpack"
 )
+
+type inProgress struct {
+	entries sync.Map
+}
+
+func newInProgress() *inProgress {
+	return &inProgress{}
+}
+
+func (inp *inProgress) load(key string) (*broadCaster, bool) {
+	val, ok := inp.entries.Load(key)
+	if ok {
+		return val.(*broadCaster), true
+	}
+	return nil, false
+}
+
+func (inp *inProgress) loadOrStore(key string) (*broadCaster, bool) {
+	bc, ok := inp.entries.LoadOrStore(key, newBroadcaster())
+	return bc.(*broadCaster), ok
+}
+
+func (inp *inProgress) delete(key string) {
+	inp.entries.Delete(key)
+}
+
+type broadCaster struct {
+	c        *sync.Cond
+	finished bool
+	err      error
+}
+
+func newBroadcaster() *broadCaster {
+	return &broadCaster{
+		c: sync.NewCond(&sync.Mutex{}),
+	}
+}
+
+func (br *broadCaster) wait() error {
+	br.c.L.Lock()
+	defer br.c.L.Unlock()
+	// Check if the broadcaster has been "finished" which boils down to either us reaching `Commit` or `Remove`. It's a safeguard to protect
+	// a waiter getting into wait shortly after broadcast has been fired.
+	for !br.finished {
+		br.c.Wait()
+	}
+	return br.err
+}
+
+// broadcast invokes 'work' and then broadcasts to all waiters to wake up
+func (br *broadCaster) broadcast(work func()) {
+	br.c.L.Lock()
+	defer br.c.L.Unlock()
+
+	work()
+	// Alert all waiters.
+	br.c.Broadcast()
+}
 
 type snapshotter struct {
 	snapshots.Snapshotter
 	name string
 	db   *DB
 	l    sync.RWMutex
+	// inp holds all active extraction snapshots before becoming committed/removed. This can be used to wait on the
+	// result of an unpack instead of doing the same work twice if one is already underway.
+	inp *inProgress
 }
 
 // newSnapshotter returns a new Snapshotter which namespaces the given snapshot
@@ -55,6 +117,7 @@ func newSnapshotter(db *DB, name string, sn snapshots.Snapshotter) *snapshotter 
 		Snapshotter: sn,
 		name:        name,
 		db:          db,
+		inp:         newInProgress(),
 	}
 }
 
@@ -281,34 +344,67 @@ func (s *snapshotter) View(ctx context.Context, key, parent string, opts ...snap
 	return s.createSnapshot(ctx, key, parent, true, opts)
 }
 
-func (s *snapshotter) createSnapshot(ctx context.Context, key, parent string, readonly bool, opts []snapshots.Opt) ([]mount.Mount, error) {
+func (s *snapshotter) createSnapshot(ctx context.Context, key, parent string, readonly bool, opts []snapshots.Opt) (_ []mount.Mount, err error) {
 	s.l.RLock()
-	defer s.l.RUnlock()
 
 	ns, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {
+		s.l.RUnlock()
 		return nil, err
 	}
 
 	var base snapshots.Info
 	for _, opt := range opts {
 		if err := opt(&base); err != nil {
+			s.l.RUnlock()
 			return nil, err
 		}
 	}
 
 	if err := validateSnapshot(&base); err != nil {
+		s.l.RUnlock()
 		return nil, err
 	}
 
 	var (
-		target  = base.Labels[labelSnapshotRef]
-		bparent string
-		bkey    string
-		bopts   = []snapshots.Opt{
+		target               = base.Labels[labelSnapshotRef]
+		_, disableSameUnpack = base.Labels[labelDisableSameUnpack]
+		bparent              string
+		bkey                 string
+		bopts                = []snapshots.Opt{
 			snapshots.WithLabels(snapshots.FilterInheritedLabels(base.Labels)),
 		}
 	)
+
+	if disableSameUnpack {
+		bc, ok := s.inp.loadOrStore(key)
+		if ok {
+			// Wait for someone to broadcast that an active snapshot with the same key was either committed or removed.
+			s.l.RUnlock()
+			err := bc.wait()
+			// If the extraction snapshot we were waiting on wasn't removed, then it either
+			// 1. Succeeded and we return ErrAlreadyExists as the unpacker special cases this error and will check if it can find the commited
+			// snapshot.
+			// 2. Failed and we return the error as is.
+			if err == nil {
+				return nil, errdefs.ErrAlreadyExists
+			}
+			return nil, err
+		} else {
+			// Else this is the first snapshot with this key, make sure to broadcast any errors if we
+			// error out in this call.
+			defer func() {
+				if err != nil {
+					bc.broadcast(func() {
+						bc.err = err
+						bc.finished = true
+						s.inp.delete(key)
+					})
+				}
+			}()
+		}
+	}
+	defer s.l.RUnlock()
 
 	if err := update(ctx, s.db, func(tx *bolt.Tx) error {
 		bkt, err := createSnapshotterBucket(tx, ns, s.name)
@@ -492,9 +588,22 @@ func (s *snapshotter) createSnapshot(ctx context.Context, key, parent string, re
 	return m, nil
 }
 
-func (s *snapshotter) Commit(ctx context.Context, name, key string, opts ...snapshots.Opt) error {
+func (s *snapshotter) Commit(ctx context.Context, name, key string, opts ...snapshots.Opt) (err error) {
 	s.l.RLock()
 	defer s.l.RUnlock()
+
+	defer func() {
+		bc, ok := s.inp.load(key)
+		if ok {
+			bc.broadcast(func() {
+				// Set the error that commit will return and then broadcast to all waiters that a commit has successfully
+				// completed/failed.
+				bc.finished = true
+				bc.err = err
+				s.inp.delete(key)
+			})
+		}
+	}()
 
 	ns, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {
@@ -623,9 +732,24 @@ func (s *snapshotter) Commit(ctx context.Context, name, key string, opts ...snap
 
 }
 
-func (s *snapshotter) Remove(ctx context.Context, key string) error {
+func (s *snapshotter) Remove(ctx context.Context, key string) (err error) {
 	s.l.RLock()
 	defer s.l.RUnlock()
+
+	defer func() {
+		// Broadcast to the waiters so we can return and try again. The unpacker logic special cases ErrAlreadyExists to handle remote
+		// snapshotters, but it makes sure that the snapshot actually does exist by statting the snapshot. If the stat fails, it will
+		// retry two more times. Whatever waiter ends up back in Prepare first will store the key and the others will go back to waiting
+		// until success/failure.
+		bc, ok := s.inp.load(key)
+		if ok {
+			bc.broadcast(func() {
+				bc.err = errdefs.ErrAlreadyExists
+				bc.finished = true
+				s.inp.delete(key)
+			})
+		}
+	}()
 
 	ns, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {

--- a/pull.go
+++ b/pull.go
@@ -19,6 +19,7 @@ package containerd
 import (
 	"context"
 
+	"github.com/containerd/containerd/diff"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/platforms"
@@ -65,6 +66,13 @@ func (c *Client) Pull(ctx context.Context, ref string, opts ...RemoteOpt) (_ Ima
 	var unpacks int32
 	var unpackEg *errgroup.Group
 	var unpackWrapper func(f images.Handler) images.Handler
+
+	if pullCtx.Labels != nil {
+		diffLabels := diff.FilterDiffLabels(pullCtx.Labels)
+		if len(diffLabels) > 0 {
+			pullCtx.UnpackOpts = append(pullCtx.UnpackOpts, WithUnpackConfigApplyOpts(diff.WithStringPayloads(diffLabels)))
+		}
+	}
 
 	if pullCtx.Unpack {
 		// unpacker only supports schema 2 image, for schema 1 this is noop.

--- a/unpacker.go
+++ b/unpacker.go
@@ -154,8 +154,15 @@ EachLayer:
 		)
 
 		for try := 1; try <= 3; try++ {
+			// If we want to avoid unpacking the same layer in parallel, we need to use a key format that will
+			// intentionally cause collisions for the same layer. This is how we'll know an active snapshot is
+			// underway already, along with intentional tracking in the metadata snapshotter layer.
+			if rCtx.DisableSameLayerUnpack {
+				key = fmt.Sprintf(snapshots.UnpackKeyPrefix+"-%s", chainID)
+			} else {
+				key = fmt.Sprintf(snapshots.UnpackKeyFormat, uniquePart(), chainID)
+			}
 			// Prepare snapshot with from parent, label as root
-			key = fmt.Sprintf(snapshots.UnpackKeyFormat, uniquePart(), chainID)
 			mounts, err = sn.Prepare(ctx, key, parent.String(), opts...)
 			if err != nil {
 				if errdefs.IsAlreadyExists(err) {
@@ -206,9 +213,15 @@ EachLayer:
 
 		select {
 		case <-ctx.Done():
+			if rCtx.DisableSameLayerUnpack {
+				abort()
+			}
 			return ctx.Err()
 		case err := <-fetchErr:
 			if err != nil {
+				if rCtx.DisableSameLayerUnpack {
+					abort()
+				}
 				return err
 			}
 		case <-fetchC[i-fetchOffset]:

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,0 +1,105 @@
+github.com/beorn7/perks                             v1.0.1
+github.com/BurntSushi/toml                          v0.3.1
+github.com/cespare/xxhash/v2                        v2.1.1
+github.com/containerd/btrfs                         404b9149801e455c8076f615b06dc0abee0a977a
+github.com/containerd/cgroups                       318312a373405e5e91134d8063d04d59768a1bff
+github.com/containerd/console                       v1.0.0
+github.com/containerd/continuity                    efbc4488d8fe1bdc16bde3b2d2990d9b3a899165
+github.com/containerd/fifo                          f15a3290365b9d2627d189e619ab4008e0069caf
+github.com/containerd/go-runc                       7016d3ce2328dd2cb1192b2076ebd565c4e8df0c
+github.com/containerd/ttrpc                         v1.0.1
+github.com/containerd/typeurl                       v1.0.1
+github.com/coreos/go-systemd/v22                    v22.1.0
+github.com/cpuguy83/go-md2man/v2                    v2.0.0
+github.com/docker/go-events                         e31b211e4f1cd09aa76fe4ac244571fab96ae47f
+github.com/docker/go-metrics                        v0.0.1
+github.com/docker/go-units                          v0.4.0
+github.com/godbus/dbus/v5                           v5.0.3
+github.com/gogo/googleapis                          v1.3.2
+github.com/gogo/protobuf                            v1.3.1
+github.com/golang/protobuf                          v1.3.5
+github.com/google/go-cmp                            v0.2.0
+github.com/google/uuid                              v1.1.1
+github.com/grpc-ecosystem/go-grpc-prometheus        v1.2.0
+github.com/hashicorp/errwrap                        v1.0.0
+github.com/hashicorp/go-multierror                  v1.0.0
+github.com/hashicorp/golang-lru                     v0.5.3
+github.com/imdario/mergo                            v0.3.7
+github.com/konsorten/go-windows-terminal-sequences  v1.0.3
+github.com/matttproud/golang_protobuf_extensions    v1.0.1
+github.com/Microsoft/go-winio                       v0.4.14
+github.com/Microsoft/hcsshim                        77c0270424049ab4c850c076601add11882e7c1e
+github.com/opencontainers/go-digest                 v1.0.0
+github.com/opencontainers/image-spec                v1.0.1
+github.com/opencontainers/runc                      v1.0.0-rc92
+github.com/opencontainers/runtime-spec              4d89ac9fbff6c455f46a5bb59c6b1bb7184a5e43 # v1.0.3-0.20200728170252-4d89ac9fbff6
+github.com/pkg/errors                               v0.9.1
+github.com/prometheus/client_golang                 v1.6.0
+github.com/prometheus/client_model                  v0.2.0
+github.com/prometheus/common                        v0.9.1
+github.com/prometheus/procfs                        v0.0.11
+github.com/russross/blackfriday/v2                  v2.0.1
+github.com/shurcooL/sanitized_anchor_name           v1.0.0
+github.com/sirupsen/logrus                          v1.6.0
+github.com/syndtr/gocapability                      d98352740cb2c55f81556b63d4a1ec64c5a319c2
+github.com/urfave/cli                               v1.22.1 # NOTE: urfave/cli must be <= v1.22.1 due to a regression: https://github.com/urfave/cli/issues/1092
+go.etcd.io/bbolt                                    v1.3.5
+go.opencensus.io                                    v0.22.0
+golang.org/x/net                                    ab34263943818b32f575efc978a3d24e80b04bd7
+golang.org/x/sync                                   42b317875d0fa942474b76e1b46a6060d720ae6e
+golang.org/x/sys                                    ed371f2e16b4b305ee99df548828de367527b76b
+golang.org/x/text                                   v0.3.3
+google.golang.org/genproto                          e50cd9704f63023d62cd06a1994b98227fc4d21a
+google.golang.org/grpc                              v1.27.1
+gotest.tools/v3                                     v3.0.2
+
+# cgroups dependencies
+github.com/cilium/ebpf                              1c8d4c9ef7759622653a1d319284a44652333b28
+
+# cri dependencies
+github.com/containerd/cri                           adc0b6a578ed6f646bb24c1c639d65b70e14cccc # release/1.4
+github.com/davecgh/go-spew                          v1.1.1
+github.com/docker/docker                            4634ce647cf2ce2c6031129ccd109e557244986f
+github.com/docker/spdystream                        449fdfce4d962303d702fec724ef0ad181c92528
+github.com/emicklei/go-restful                      v2.9.5
+github.com/go-logr/logr                             v0.2.0
+github.com/google/gofuzz                            v1.1.0
+github.com/json-iterator/go                         v1.1.10
+github.com/modern-go/concurrent                     1.0.3
+github.com/modern-go/reflect2                       v1.0.1
+github.com/opencontainers/selinux                   v1.6.0
+github.com/tchap/go-patricia                        v2.2.6
+github.com/willf/bitset                             v1.1.11
+golang.org/x/crypto                                 75b288015ac94e66e3d6715fb68a9b41bf046ec2
+golang.org/x/oauth2                                 858c2ad4c8b6c5d10852cb89079f6ca1c7309787
+golang.org/x/time                                   555d28b269f0569763d25dbe1a237ae74c6bcc82
+gopkg.in/inf.v0                                     v0.9.1
+gopkg.in/yaml.v2                                    v2.2.8
+k8s.io/api                                          v0.19.4
+k8s.io/apimachinery                                 v0.19.4
+k8s.io/apiserver                                    v0.19.4
+k8s.io/client-go                                    v0.19.4
+k8s.io/cri-api                                      v0.19.4
+k8s.io/klog/v2                                      v2.2.0
+k8s.io/utils                                        d5654de09c73da55eb19ae4ab4f734f7a61747a6
+sigs.k8s.io/structured-merge-diff/v4                v4.0.1
+sigs.k8s.io/yaml                                    v1.2.0
+
+# cni dependencies
+github.com/containerd/go-cni                        v1.0.1
+github.com/containernetworking/cni                  v0.8.0
+github.com/containernetworking/plugins              v0.8.6
+github.com/fsnotify/fsnotify                        v1.4.9
+
+# image decrypt depedencies
+github.com/containerd/imgcrypt                      v1.0.1
+github.com/containers/ocicrypt                      v1.0.1
+github.com/fullsailor/pkcs7                         8306686428a5fe132eac8cb7c4848af725098bd4
+gopkg.in/square/go-jose.v2                          v2.3.1
+
+# zfs dependencies
+github.com/containerd/zfs                           9abf673ca6ff9ab8d9bd776a4ceff8f6dc699c3d
+github.com/mistifyio/go-zfs                         f784269be439d704d3dfa1906f45dd848fed2beb
+
+# aufs dependencies
+github.com/containerd/aufs                          371312c1e31c210a21e49bf3dfd3f31729ed9f2f


### PR DESCRIPTION
As part of the work in https://github.com/kevpar/containerd/pull/37, we found that there were three PRs that were made directly to our `fork/release/1.4` branch but not additionally added to our `fork/main` branch. We need to cherry-pick those changes to our `fork/main` branch so that we don't accidentally lose any code that we depend on once we create more release branches for later releases of containerd. 

The PRs that are cherry-picked here are:
- https://github.com/kevpar/containerd/pull/28
- https://github.com/kevpar/containerd/pull/33
- https://github.com/kevpar/containerd/pull/21