### PR TITLE
[fork/release/1.4] Cherry-pick: Change Wrapf of non-error to an actual error

### DIFF
--- a/content/local/store.go
+++ b/content/local/store.go
@@ -502,7 +502,7 @@ func (s *store) resumeStatus(ref string, total int64, digester digest.Digester) 
 	if ref != status.Ref {
 		// NOTE(stevvooe): This is fairly catastrophic. Either we have some
 		// layout corruption or a hash collision for the ref key.
-		return status, errors.Wrapf(err, "ref key does not match: %v != %v", ref, status.Ref)
+		return status, errors.Errorf("ref key does not match: %v != %v", ref, status.Ref)
 	}
 
 	if total > 0 && status.Total > 0 && total != status.Total {


### PR DESCRIPTION
(cherry picked from commit edfd8d59937faeb36f40b8baeff488a6d693ef49)

This cherry-picks a change for an issue in the content store where a nil error was being wrapped via `errors.Wrapf`, 
which ends up foregoing actually returning an error and [instead returns nil](https://pkg.go.dev/github.com/pkg/errors#Wrapf). 

More details: https://github.com/containerd/containerd/issues/3974

This is already present in fork/main, just not here.