### PR TITLE
Revert "Add option to skip unpacking the same layer in parallel"

### DIFF
--- a/client.go
+++ b/client.go
@@ -371,10 +371,6 @@ type RemoteContext struct {
 	// AllMetadata downloads all manifests and known-configuration files
 	AllMetadata bool
 
-	// DisableSameLayerUnpack prevents a parallel unpack of the same image layer and will wait for the first
-	// in line to complete before either returning the error if there was one, or returning ErrAlreadyExists.
-	DisableSameLayerUnpack bool
-
 	// ChildLabelMap sets the labels used to reference child objects in the content
 	// store. By default, all GC reference labels will be set for all fetched content.
 	ChildLabelMap func(ocispec.Descriptor) []string

--- a/client_opts.go
+++ b/client_opts.go
@@ -259,14 +259,3 @@ func WithAllMetadata() RemoteOpt {
 		return nil
 	}
 }
-
-// WithDisableSameLayerUnpack sets the option that disallows Containerd from unpacking the same layer in parallel. This helps de-duplicate work
-// if pulling multiple images that share layers.
-func WithDisableSameLayerUnpack() RemoteOpt {
-	return func(client *Client, c *RemoteContext) error {
-		c.DisableSameLayerUnpack = true
-		c.SnapshotterOpts = append(c.SnapshotterOpts,
-			snapshots.WithLabels(map[string]string{"containerd.io/snapshot/disable-same-unpack": ""}))
-		return nil
-	}
-}

--- a/unpacker.go
+++ b/unpacker.go
@@ -154,15 +154,8 @@ EachLayer:
 		)
 
 		for try := 1; try <= 3; try++ {
-			// If we want to avoid unpacking the same layer in parallel, we need to use a key format that will
-			// intentionally cause collisions for the same layer. This is how we'll know an active snapshot is
-			// underway already, along with intentional tracking in the metadata snapshotter layer.
-			if rCtx.DisableSameLayerUnpack {
-				key = fmt.Sprintf(snapshots.UnpackKeyPrefix+"-%s", chainID)
-			} else {
-				key = fmt.Sprintf(snapshots.UnpackKeyFormat, uniquePart(), chainID)
-			}
 			// Prepare snapshot with from parent, label as root
+			key = fmt.Sprintf(snapshots.UnpackKeyFormat, uniquePart(), chainID)
 			mounts, err = sn.Prepare(ctx, key, parent.String(), opts...)
 			if err != nil {
 				if errdefs.IsAlreadyExists(err) {
@@ -213,15 +206,9 @@ EachLayer:
 
 		select {
 		case <-ctx.Done():
-			if rCtx.DisableSameLayerUnpack {
-				abort()
-			}
 			return ctx.Err()
 		case err := <-fetchErr:
 			if err != nil {
-				if rCtx.DisableSameLayerUnpack {
-					abort()
-				}
 				return err
 			}
 		case <-fetchC[i-fetchOffset]:


### PR DESCRIPTION
This reverts commit 62e059d9a60bc6a9e70dff94f60ed4b8cc8a97c5.

There was a client based approach checked into upstream that would be much better to swap to. That will follow this after we 
update main to the 1.6 commits first.