### PR TITLE
Swap to client side approach for parallel image pull improvements

### DIFF
--- a/client.go
+++ b/client.go
@@ -352,10 +352,6 @@ type RemoteContext struct {
 	// AllMetadata downloads all manifests and known-configuration files
 	AllMetadata bool
 
-	// DisableSameLayerUnpack prevents a parallel unpack of the same image layer and will wait for the first
-	// in line to complete before either returning the error if there was one, or returning ErrAlreadyExists.
-	DisableSameLayerUnpack bool
-
 	// ChildLabelMap sets the labels used to reference child objects in the content
 	// store. By default, all GC reference labels will be set for all fetched content.
 	ChildLabelMap func(ocispec.Descriptor) []string

--- a/client_opts.go
+++ b/client_opts.go
@@ -242,14 +242,3 @@ func WithAllMetadata() RemoteOpt {
 		return nil
 	}
 }
-
-// WithDisableSameLayerUnpack sets the option that disallows Containerd from unpacking the same layer in parallel. This helps de-duplicate work
-// if pulling multiple images that share layers.
-func WithDisableSameLayerUnpack() RemoteOpt {
-	return func(client *Client, c *RemoteContext) error {
-		c.DisableSameLayerUnpack = true
-		c.SnapshotterOpts = append(c.SnapshotterOpts,
-			snapshots.WithLabels(map[string]string{"containerd.io/snapshot/disable-same-unpack": ""}))
-		return nil
-	}
-}

--- a/pkg/kmutex/kmutex.go
+++ b/pkg/kmutex/kmutex.go
@@ -1,0 +1,105 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package kmutex provides synchronization primitives to lock/unlock resource by unique key.
+package kmutex
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"golang.org/x/sync/semaphore"
+)
+
+// KeyedLocker is the interface for acquiring locks based on string.
+type KeyedLocker interface {
+	Lock(ctx context.Context, key string) error
+	Unlock(key string)
+}
+
+func New() KeyedLocker {
+	return newKeyMutex()
+}
+
+func newKeyMutex() *keyMutex {
+	return &keyMutex{
+		locks: make(map[string]*klock),
+	}
+}
+
+type keyMutex struct {
+	mu sync.Mutex
+
+	locks map[string]*klock
+}
+
+type klock struct {
+	*semaphore.Weighted
+	ref int
+}
+
+func (km *keyMutex) Lock(ctx context.Context, key string) error {
+	km.mu.Lock()
+
+	l, ok := km.locks[key]
+	if !ok {
+		km.locks[key] = &klock{
+			Weighted: semaphore.NewWeighted(1),
+		}
+		l = km.locks[key]
+	}
+	l.ref++
+	km.mu.Unlock()
+
+	if err := l.Acquire(ctx, 1); err != nil {
+		km.mu.Lock()
+		defer km.mu.Unlock()
+
+		l.ref--
+
+		if l.ref < 0 {
+			panic(fmt.Errorf("kmutex: release of unlocked key %v", key))
+		}
+
+		if l.ref == 0 {
+			delete(km.locks, key)
+		}
+		return err
+	}
+	return nil
+}
+
+func (km *keyMutex) Unlock(key string) {
+	km.mu.Lock()
+	defer km.mu.Unlock()
+
+	l, ok := km.locks[key]
+	if !ok {
+		panic(fmt.Errorf("kmutex: unlock of unlocked key %v", key))
+	}
+	l.Release(1)
+
+	l.ref--
+
+	if l.ref < 0 {
+		panic(fmt.Errorf("kmutex: released of unlocked key %v", key))
+	}
+
+	if l.ref == 0 {
+		delete(km.locks, key)
+	}
+}

--- a/pkg/kmutex/kmutex_test.go
+++ b/pkg/kmutex/kmutex_test.go
@@ -1,0 +1,175 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package kmutex
+
+import (
+	"context"
+	"math/rand"
+	"runtime"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/pkg/seed"
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	seed.WithTimeAndRand()
+}
+
+func TestBasic(t *testing.T) {
+	t.Parallel()
+
+	km := newKeyMutex()
+	ctx := context.Background()
+
+	km.Lock(ctx, "c1")
+	km.Lock(ctx, "c2")
+
+	assert.Equal(t, len(km.locks), 2)
+	assert.Equal(t, km.locks["c1"].ref, 1)
+	assert.Equal(t, km.locks["c2"].ref, 1)
+
+	checkWaitFn := func(key string, num int) {
+		retries := 100
+		waitLock := false
+
+		for i := 0; i < retries; i++ {
+			// prevent from data-race
+			km.mu.Lock()
+			ref := km.locks[key].ref
+			km.mu.Unlock()
+
+			if ref == num {
+				waitLock = true
+				break
+			}
+			time.Sleep(time.Duration(rand.Int63n(100)) * time.Millisecond)
+		}
+		assert.Equal(t, waitLock, true)
+	}
+
+	// should acquire successfully after release
+	{
+		waitCh := make(chan struct{})
+		go func() {
+			defer close(waitCh)
+
+			km.Lock(ctx, "c1")
+		}()
+		checkWaitFn("c1", 2)
+
+		km.Unlock("c1")
+
+		<-waitCh
+		assert.Equal(t, km.locks["c1"].ref, 1)
+	}
+
+	// failed to acquire if context cancel
+	{
+		var errCh = make(chan error, 1)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			errCh <- km.Lock(ctx, "c1")
+		}()
+
+		checkWaitFn("c1", 2)
+
+		cancel()
+		assert.Equal(t, <-errCh, context.Canceled)
+		assert.Equal(t, km.locks["c1"].ref, 1)
+	}
+}
+
+func TestReleasePanic(t *testing.T) {
+	t.Parallel()
+
+	km := newKeyMutex()
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("release of unlocked key did not panic")
+		}
+	}()
+
+	km.Unlock(t.Name())
+}
+
+func TestMultileAcquireOnKeys(t *testing.T) {
+	t.Parallel()
+
+	km := newKeyMutex()
+	nloops := 10000
+	nproc := runtime.GOMAXPROCS(0)
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	for i := 0; i < nproc; i++ {
+		wg.Add(1)
+
+		go func(key string) {
+			defer wg.Done()
+
+			for i := 0; i < nloops; i++ {
+				km.Lock(ctx, key)
+
+				time.Sleep(time.Duration(rand.Int63n(100)) * time.Nanosecond)
+
+				km.Unlock(key)
+			}
+		}("key-" + strconv.Itoa(i))
+	}
+	wg.Wait()
+}
+
+func TestMultiAcquireOnSameKey(t *testing.T) {
+	t.Parallel()
+
+	km := newKeyMutex()
+	key := "c1"
+	ctx := context.Background()
+
+	assert.Nil(t, km.Lock(ctx, key))
+
+	nproc := runtime.GOMAXPROCS(0)
+	nloops := 10000
+
+	var wg sync.WaitGroup
+	for i := 0; i < nproc; i++ {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			for i := 0; i < nloops; i++ {
+				km.Lock(ctx, key)
+
+				time.Sleep(time.Duration(rand.Int63n(100)) * time.Nanosecond)
+
+				km.Unlock(key)
+			}
+		}()
+	}
+	km.Unlock(key)
+	wg.Wait()
+
+	// c1 key has been released so the it should not have any klock.
+	assert.Equal(t, len(km.locks), 0)
+}

--- a/pkg/kmutex/noop.go
+++ b/pkg/kmutex/noop.go
@@ -1,0 +1,33 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package kmutex
+
+import "context"
+
+func NewNoop() KeyedLocker {
+	return &noopMutex{}
+}
+
+type noopMutex struct {
+}
+
+func (*noopMutex) Lock(_ context.Context, _ string) error {
+	return nil
+}
+
+func (*noopMutex) Unlock(_ string) {
+}

--- a/unpacker.go
+++ b/unpacker.go
@@ -137,15 +137,8 @@ EachLayer:
 		)
 
 		for try := 1; try <= 3; try++ {
-			// If we want to avoid unpacking the same layer in parallel, we need to use a key format that will
-			// intentionally cause collisions for the same layer. This is how we'll know an active snapshot is
-			// underway already, along with intentional tracking in the metadata snapshotter layer.
-			if rCtx.DisableSameLayerUnpack {
-				key = fmt.Sprintf(snapshots.UnpackKeyPrefix+"-%s", chainID)
-			} else {
-				key = fmt.Sprintf(snapshots.UnpackKeyFormat, uniquePart(), chainID)
-			}
 			// Prepare snapshot with from parent, label as root
+			key = fmt.Sprintf(snapshots.UnpackKeyFormat, uniquePart(), chainID)
 			mounts, err = sn.Prepare(ctx, key, parent.String(), opts...)
 			if err != nil {
 				if errdefs.IsAlreadyExists(err) {
@@ -196,15 +189,9 @@ EachLayer:
 
 		select {
 		case <-ctx.Done():
-			if rCtx.DisableSameLayerUnpack {
-				abort()
-			}
 			return ctx.Err()
 		case err := <-fetchErr:
 			if err != nil {
-				if rCtx.DisableSameLayerUnpack {
-					abort()
-				}
 				return err
 			}
 		case <-fetchC[i-fetchOffset]:

--- a/unpacker.go
+++ b/unpacker.go
@@ -31,6 +31,7 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/pkg/kmutex"
 	"github.com/containerd/containerd/snapshots"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
@@ -58,7 +59,9 @@ func (c *Client) newUnpacker(ctx context.Context, rCtx *RemoteContext) (*unpacke
 	if err != nil {
 		return nil, err
 	}
-	var config UnpackConfig
+	var config = UnpackConfig{
+		DuplicationSuppressor: kmutex.NewNoop(),
+	}
 	for _, o := range rCtx.UnpackOpts {
 		if err := o(ctx, &config); err != nil {
 			return nil, err
@@ -110,15 +113,20 @@ func (u *unpacker) unpack(
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-EachLayer:
-	for i, desc := range layers {
+	doUnpackFn := func(i int, desc ocispec.Descriptor) error {
 		parent := identity.ChainID(chain)
 		chain = append(chain, diffIDs[i])
-
 		chainID := identity.ChainID(chain).String()
+
+		unlock, err := u.lockSnChainID(ctx, chainID)
+		if err != nil {
+			return err
+		}
+		defer unlock()
+
 		if _, err := sn.Stat(ctx, chainID); err == nil {
 			// no need to handle
-			continue
+			return nil
 		} else if !errdefs.IsNotFound(err) {
 			return errors.Wrapf(err, "failed to stat snapshot %s", chainID)
 		}
@@ -150,7 +158,7 @@ EachLayer:
 						log.G(ctx).WithField("key", key).WithField("chainid", chainID).Debug("extraction snapshot already exists, chain id not found")
 					} else {
 						// no need to handle, snapshot now found with chain id
-						continue EachLayer
+						return nil
 					}
 				} else {
 					return errors.Wrapf(err, "failed to prepare extraction snapshot %q", key)
@@ -210,7 +218,7 @@ EachLayer:
 		if err = sn.Commit(ctx, chainID, key, opts...); err != nil {
 			abort()
 			if errdefs.IsAlreadyExists(err) {
-				continue
+				return nil
 			}
 			return errors.Wrapf(err, "failed to commit snapshot %s", key)
 		}
@@ -226,7 +234,13 @@ EachLayer:
 		if _, err := cs.Update(ctx, cinfo, "labels.containerd.io/uncompressed"); err != nil {
 			return err
 		}
+		return nil
+	}
 
+	for i, desc := range layers {
+		if err := doUnpackFn(i, desc); err != nil {
+			return err
+		}
 	}
 
 	chainID := identity.ChainID(chain).String()
@@ -254,17 +268,22 @@ func (u *unpacker) fetch(ctx context.Context, h images.Handler, layers []ocispec
 		desc := desc
 		i := i
 
-		if u.limiter != nil {
-			if err := u.limiter.Acquire(ctx, 1); err != nil {
-				return err
-			}
+		if err := u.acquire(ctx); err != nil {
+			return err
 		}
 
 		eg.Go(func() error {
-			_, err := h.Handle(ctx2, desc)
-			if u.limiter != nil {
-				u.limiter.Release(1)
+			unlock, err := u.lockBlobDescriptor(ctx2, desc)
+			if err != nil {
+				u.release()
+				return err
 			}
+
+			_, err = h.Handle(ctx2, desc)
+
+			unlock()
+			u.release()
+
 			if err != nil && !errors.Is(err, images.ErrSkipDesc) {
 				return err
 			}
@@ -289,7 +308,13 @@ func (u *unpacker) handlerWrapper(
 			layers = map[digest.Digest][]ocispec.Descriptor{}
 		)
 		return images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+			unlock, err := u.lockBlobDescriptor(ctx, desc)
+			if err != nil {
+				return nil, err
+			}
+
 			children, err := f.Handle(ctx, desc)
+			unlock()
 			if err != nil {
 				return children, err
 			}
@@ -330,6 +355,50 @@ func (u *unpacker) handlerWrapper(
 			return children, nil
 		})
 	}, eg
+}
+
+func (u *unpacker) acquire(ctx context.Context) error {
+	if u.limiter == nil {
+		return nil
+	}
+	return u.limiter.Acquire(ctx, 1)
+}
+
+func (u *unpacker) release() {
+	if u.limiter == nil {
+		return
+	}
+	u.limiter.Release(1)
+}
+
+func (u *unpacker) lockSnChainID(ctx context.Context, chainID string) (func(), error) {
+	key := u.makeChainIDKeyWithSnapshotter(chainID)
+
+	if err := u.config.DuplicationSuppressor.Lock(ctx, key); err != nil {
+		return nil, err
+	}
+	return func() {
+		u.config.DuplicationSuppressor.Unlock(key)
+	}, nil
+}
+
+func (u *unpacker) lockBlobDescriptor(ctx context.Context, desc ocispec.Descriptor) (func(), error) {
+	key := u.makeBlobDescriptorKey(desc)
+
+	if err := u.config.DuplicationSuppressor.Lock(ctx, key); err != nil {
+		return nil, err
+	}
+	return func() {
+		u.config.DuplicationSuppressor.Unlock(key)
+	}, nil
+}
+
+func (u *unpacker) makeChainIDKeyWithSnapshotter(chainID string) string {
+	return fmt.Sprintf("sn://%s/%v", u.snapshotter, chainID)
+}
+
+func (u *unpacker) makeBlobDescriptorKey(desc ocispec.Descriptor) string {
+	return fmt.Sprintf("blob://%v", desc.Digest)
 }
 
 func uniquePart() string {


### PR DESCRIPTION
This change reverts "Add option to skip unpacking the same layer in parallel" https://github.com/kevpar/containerd/commit/3095bf1131aaa9ea17ef0b1ca2a7d9d0862b507c and cherry-picks in the client side based approach from upstream. 