### PR TITLE
Remove check for osversion in windows matcher

### DIFF
--- a/platforms/defaults_windows.go
+++ b/platforms/defaults_windows.go
@@ -47,11 +47,7 @@ type matchComparer struct {
 // Match matches platform with the same windows major, minor
 // and build version.
 func (m matchComparer) Match(p imagespec.Platform) bool {
-	if m.defaults.Match(p) {
-		// TODO(windows): Figure out whether OSVersion is deprecated.
-		return strings.HasPrefix(p.OSVersion, m.osVersionPrefix)
-	}
-	return false
+	return m.defaults.Match(p)
 }
 
 // Less sorts matched platforms in front of other platforms.


### PR DESCRIPTION
This PR removes a block of code that was added in upstream to match images based on the osversion between the host and the image being pulled. Since we support hypervisor isolated wcow, we can pull images that do not match the host osversion. 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>