### PR TITLE
Support for sharing snapshots

### DIFF
--- a/docs/ops.md
+++ b/docs/ops.md
@@ -232,3 +232,7 @@ The default is "shared". While this is largely the most desired policy, one can 
 [plugins.bolt]
 	content_sharing_policy = "isolated"
 ```
+
+In "isolated" mode, it is also possible to share only the contents of a specific namespace by adding the label `containerd.io/namespace.shareable=true` to that namespace.
+This will make its blobs available in all other namespaces even if the content sharing policy is set to "isolated".
+If the label value is set to anything other than `true`, the namespace content will not be shared.

--- a/image.go
+++ b/image.go
@@ -28,6 +28,7 @@ import (
 	"github.com/containerd/containerd/diff"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/pkg/kmutex"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/rootfs"
 	"github.com/containerd/containerd/snapshots"
@@ -287,6 +288,10 @@ type UnpackConfig struct {
 	// CheckPlatformSupported is whether to validate that a snapshotter
 	// supports an image's platform before unpacking
 	CheckPlatformSupported bool
+	// DuplicationSuppressor is used to make sure that there is only one
+	// in-flight fetch request or unpack handler for a given descriptor's
+	// digest or chain ID.
+	DuplicationSuppressor kmutex.KeyedLocker
 }
 
 // UnpackOpt provides configuration for unpack
@@ -304,6 +309,14 @@ func WithSnapshotterPlatformCheck() UnpackOpt {
 func WithUnpackConfigApplyOpts(opts ...diff.ApplyOpt) UnpackOpt {
 	return func(_ context.Context, uc *UnpackConfig) error {
 		uc.ApplyOpts = append(uc.ApplyOpts, opts...)
+		return nil
+	}
+}
+
+// WithUnpackDuplicationSuppressor sets `DuplicationSuppressor` on the UnpackConfig.
+func WithUnpackDuplicationSuppressor(suppressor kmutex.KeyedLocker) UnpackOpt {
+	return func(ctx context.Context, uc *UnpackConfig) error {
+		uc.DuplicationSuppressor = suppressor
 		return nil
 	}
 }

--- a/image.go
+++ b/image.go
@@ -355,7 +355,7 @@ func (i *image) Unpack(ctx context.Context, snapshotterName string, opts ...Unpa
 
 	for _, layer := range layers {
 		unpacked, err = rootfs.ApplyLayerWithOpts(ctx, layer, chain, sn, a, config.SnapshotOpts, config.ApplyOpts)
-		if err != nil {
+		if err != nil && !errdefs.IsAlreadyExists(err) {
 			return err
 		}
 

--- a/integration/client/content_test.go
+++ b/integration/client/content_test.go
@@ -41,7 +41,7 @@ func newContentStore(ctx context.Context, root string) (context.Context, content
 		name  = testsuite.Name(ctx)
 	)
 
-	wrap := func(ctx context.Context) (context.Context, func(context.Context) error, error) {
+	wrap := func(ctx context.Context, sharedNS bool) (context.Context, func(context.Context) error, error) {
 		n := atomic.AddUint64(&count, 1)
 		ctx = namespaces.WithNamespace(ctx, fmt.Sprintf("%s-n%d", name, n))
 		return client.WithLease(ctx)

--- a/labels/labels.go
+++ b/labels/labels.go
@@ -19,3 +19,7 @@ package labels
 // LabelUncompressed is added to compressed layer contents.
 // The value is digest of the uncompressed content.
 const LabelUncompressed = "containerd.io/uncompressed"
+
+// LabelSharedNamespace is added to a namespace to allow that namespaces
+// contents to be shared.
+const LabelSharedNamespace = "containerd.io/namespace.shareable"

--- a/metadata/content_test.go
+++ b/metadata/content_test.go
@@ -76,7 +76,7 @@ func TestContent(t *testing.T) {
 	testsuite.ContentCrossNSSharedSuite(t, "metadata", createContentStoreWithPolicy())
 	testsuite.ContentCrossNSIsolatedSuite(
 		t, "metadata", createContentStoreWithPolicy([]DBOpt{
-			WithPolicyIsolated,
+			WithContentPolicyIsolated,
 		}...))
 }
 

--- a/metadata/content_test.go
+++ b/metadata/content_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/containerd/containerd/content/local"
 	"github.com/containerd/containerd/content/testsuite"
 	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/labels"
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/namespaces"
 	digest "github.com/opencontainers/go-digest"
@@ -52,9 +53,18 @@ func createContentStore(ctx context.Context, root string, opts ...DBOpt) (contex
 		count uint64
 		name  = testsuite.Name(ctx)
 	)
-	wrap := func(ctx context.Context) (context.Context, func(context.Context) error, error) {
+	wrap := func(ctx context.Context, sharedNS bool) (context.Context, func(context.Context) error, error) {
 		n := atomic.AddUint64(&count, 1)
-		return namespaces.WithNamespace(ctx, fmt.Sprintf("%s-n%d", name, n)), func(context.Context) error {
+		ctx2 := namespaces.WithNamespace(ctx, fmt.Sprintf("%s-n%d", name, n))
+		if sharedNS {
+			db.Update(func(tx *bolt.Tx) error {
+				if ns, err := namespaces.NamespaceRequired(ctx2); err == nil {
+					return NewNamespaceStore(tx).SetLabel(ctx2, ns, labels.LabelSharedNamespace, "true")
+				}
+				return err
+			})
+		}
+		return ctx2, func(context.Context) error {
 			return nil
 		}, nil
 	}
@@ -77,6 +87,10 @@ func TestContent(t *testing.T) {
 	testsuite.ContentCrossNSIsolatedSuite(
 		t, "metadata", createContentStoreWithPolicy([]DBOpt{
 			WithContentPolicyIsolated,
+		}...))
+	testsuite.ContentSharedNSIsolatedSuite(
+		t, "metadata", createContentStoreWithPolicy([]DBOpt{
+			WithPolicyIsolated,
 		}...))
 }
 

--- a/metadata/db.go
+++ b/metadata/db.go
@@ -51,14 +51,20 @@ const (
 // DBOpt configures how we set up the DB
 type DBOpt func(*dbOptions)
 
-// WithPolicyIsolated isolates contents between namespaces
-func WithPolicyIsolated(o *dbOptions) {
-	o.shared = false
+// WithContentPolicyIsolated isolates contents between namespaces
+func WithContentPolicyIsolated(o *dbOptions) {
+	o.contentShared = false
+}
+
+// WithSnapshotPolicyShared shares the snapshots between namespaces
+func WithSnapshotPolicyShared(o *dbOptions) {
+	o.snapshotShared = true
 }
 
 // dbOptions configure db options.
 type dbOptions struct {
-	shared bool
+	contentShared  bool
+	snapshotShared bool
 }
 
 // DB represents a metadata database backed by a bolt
@@ -105,7 +111,7 @@ func NewDB(db *bolt.DB, cs content.Store, ss map[string]snapshots.Snapshotter, o
 		ss:      make(map[string]*snapshotter, len(ss)),
 		dirtySS: map[string]struct{}{},
 		dbopts: dbOptions{
-			shared: true,
+			contentShared: true,
 		},
 	}
 
@@ -114,9 +120,9 @@ func NewDB(db *bolt.DB, cs content.Store, ss map[string]snapshots.Snapshotter, o
 	}
 
 	// Initialize data stores
-	m.cs = newContentStore(m, m.dbopts.shared, cs)
+	m.cs = newContentStore(m, m.dbopts.contentShared, cs)
 	for name, sn := range ss {
-		m.ss[name] = newSnapshotter(m, name, sn)
+		m.ss[name] = newSnapshotter(m, name, m.dbopts.snapshotShared, sn)
 	}
 
 	return m

--- a/metadata/snapshot_windows_test.go
+++ b/metadata/snapshot_windows_test.go
@@ -1,0 +1,154 @@
+//go:build windows
+// +build windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package metadata
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/containerd/containerd/content/local"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/plugin"
+	"github.com/containerd/containerd/snapshots"
+	"github.com/containerd/containerd/snapshots/windows"
+	bolt "go.etcd.io/bbolt"
+)
+
+func initTestDB(t *testing.T, root string, sns map[string]snapshots.Snapshotter) (*DB, func()) {
+	cs, err := local.NewStore(filepath.Join(root, "content"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bdb, err := bolt.Open(filepath.Join(root, "metadata.db"), 0644, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	db := NewDB(bdb, cs, sns, WithSnapshotPolicyShared)
+	if err := db.Init(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	return db, func() { db.db.Close() }
+}
+
+func TestSnapshotSharingSimple(t *testing.T) {
+	root, err := ioutil.TempDir("", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(root)
+
+	ic := &plugin.InitContext{
+		Root:   filepath.Join(root, "snapshotter"),
+		Config: &windows.WindowsSnapshotterConfig{},
+	}
+	windowsSn, err := windows.NewWCOWSnapshotter(ic)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sns := map[string]snapshots.Snapshotter{"windows": windowsSn}
+
+	db, closer := initTestDB(t, root, sns)
+	defer closer()
+	defer windowsSn.Close()
+
+	testsn := db.Snapshotter("windows")
+
+	ctxns1 := namespaces.WithNamespace(context.Background(), "testns1")
+	ctxns2 := namespaces.WithNamespace(context.Background(), "testns2")
+
+	labelOpt := snapshots.WithLabels(map[string]string{labelSnapshotRef: "ref1"})
+
+	if _, err = testsn.Prepare(ctxns1, "extract sn1", "", labelOpt); err != nil {
+		t.Fatal(err)
+	}
+
+	if err = testsn.Commit(ctxns1, "ref1", "extract sn1", labelOpt); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = testsn.Prepare(ctxns2, "extract sn2", "", labelOpt)
+	if err == nil || !snapshots.IsTargetSnapshotExists(err) {
+		t.Fatalf("expected already exists error, got: %s", err)
+	}
+}
+
+func TestSnapshotSharingAfterRemove(t *testing.T) {
+	root, err := ioutil.TempDir("", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(root)
+
+	ic := &plugin.InitContext{
+		Root:   filepath.Join(root, "snapshotter"),
+		Config: &windows.WindowsSnapshotterConfig{},
+	}
+	windowsSn, err := windows.NewWCOWSnapshotter(ic)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sns := map[string]snapshots.Snapshotter{"windows": windowsSn}
+
+	db, closer := initTestDB(t, root, sns)
+	defer closer()
+	defer windowsSn.Close()
+
+	testsn := db.Snapshotter("windows")
+
+	ctxns1 := namespaces.WithNamespace(context.Background(), "testns1")
+	ctxns2 := namespaces.WithNamespace(context.Background(), "testns2")
+
+	labelOpt := snapshots.WithLabels(map[string]string{labelSnapshotRef: "ref1"})
+
+	if _, err = testsn.Prepare(ctxns1, "extract sn1", "", labelOpt); err != nil {
+		t.Fatal(err)
+	}
+
+	if err = testsn.Commit(ctxns1, "ref1", "extract sn1", labelOpt); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = testsn.Prepare(ctxns2, "extract sn2", "", labelOpt)
+	if err == nil || !snapshots.IsTargetSnapshotExists(err) {
+		t.Fatalf("expected already exists error, got: %s", err)
+	}
+
+	if err = testsn.Remove(ctxns1, "ref1"); err != nil {
+		t.Fatal(err)
+	}
+
+	// check if we can still access from other namespace
+	if si, err := testsn.Stat(ctxns2, "ref1"); err != nil {
+		t.Fatal(err)
+	} else if si.Kind != snapshots.KindCommitted || si.Labels[labelSnapshotRef] != "ref1" {
+		t.Fatalf("expected snapshot Info doesn't match: %+v\n", si)
+	}
+
+	if err = testsn.Remove(ctxns2, "ref1"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/cri/server/image_pull.go
+++ b/pkg/cri/server/image_pull.go
@@ -121,6 +121,9 @@ func (c *criService) PullImage(ctx context.Context, r *runtime.PullImageRequest)
 		containerd.WithPullLabel(imageLabelKey, imageLabelValue),
 		containerd.WithMaxConcurrentDownloads(c.config.MaxConcurrentDownloads),
 		containerd.WithImageHandler(imageHandler),
+		containerd.WithUnpackOpts([]containerd.UnpackOpt{
+			containerd.WithUnpackDuplicationSuppressor(c.unpackDuplicationSuppressor),
+		}),
 	}
 
 	pullOpts = append(pullOpts, c.encryptedImagesPullOpts()...)

--- a/pkg/kmutex/kmutex.go
+++ b/pkg/kmutex/kmutex.go
@@ -1,0 +1,105 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package kmutex provides synchronization primitives to lock/unlock resource by unique key.
+package kmutex
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"golang.org/x/sync/semaphore"
+)
+
+// KeyedLocker is the interface for acquiring locks based on string.
+type KeyedLocker interface {
+	Lock(ctx context.Context, key string) error
+	Unlock(key string)
+}
+
+func New() KeyedLocker {
+	return newKeyMutex()
+}
+
+func newKeyMutex() *keyMutex {
+	return &keyMutex{
+		locks: make(map[string]*klock),
+	}
+}
+
+type keyMutex struct {
+	mu sync.Mutex
+
+	locks map[string]*klock
+}
+
+type klock struct {
+	*semaphore.Weighted
+	ref int
+}
+
+func (km *keyMutex) Lock(ctx context.Context, key string) error {
+	km.mu.Lock()
+
+	l, ok := km.locks[key]
+	if !ok {
+		km.locks[key] = &klock{
+			Weighted: semaphore.NewWeighted(1),
+		}
+		l = km.locks[key]
+	}
+	l.ref++
+	km.mu.Unlock()
+
+	if err := l.Acquire(ctx, 1); err != nil {
+		km.mu.Lock()
+		defer km.mu.Unlock()
+
+		l.ref--
+
+		if l.ref < 0 {
+			panic(fmt.Errorf("kmutex: release of unlocked key %v", key))
+		}
+
+		if l.ref == 0 {
+			delete(km.locks, key)
+		}
+		return err
+	}
+	return nil
+}
+
+func (km *keyMutex) Unlock(key string) {
+	km.mu.Lock()
+	defer km.mu.Unlock()
+
+	l, ok := km.locks[key]
+	if !ok {
+		panic(fmt.Errorf("kmutex: unlock of unlocked key %v", key))
+	}
+	l.Release(1)
+
+	l.ref--
+
+	if l.ref < 0 {
+		panic(fmt.Errorf("kmutex: released of unlocked key %v", key))
+	}
+
+	if l.ref == 0 {
+		delete(km.locks, key)
+	}
+}

--- a/pkg/kmutex/kmutex_test.go
+++ b/pkg/kmutex/kmutex_test.go
@@ -1,0 +1,175 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package kmutex
+
+import (
+	"context"
+	"math/rand"
+	"runtime"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/pkg/seed"
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	seed.WithTimeAndRand()
+}
+
+func TestBasic(t *testing.T) {
+	t.Parallel()
+
+	km := newKeyMutex()
+	ctx := context.Background()
+
+	km.Lock(ctx, "c1")
+	km.Lock(ctx, "c2")
+
+	assert.Equal(t, len(km.locks), 2)
+	assert.Equal(t, km.locks["c1"].ref, 1)
+	assert.Equal(t, km.locks["c2"].ref, 1)
+
+	checkWaitFn := func(key string, num int) {
+		retries := 100
+		waitLock := false
+
+		for i := 0; i < retries; i++ {
+			// prevent from data-race
+			km.mu.Lock()
+			ref := km.locks[key].ref
+			km.mu.Unlock()
+
+			if ref == num {
+				waitLock = true
+				break
+			}
+			time.Sleep(time.Duration(rand.Int63n(100)) * time.Millisecond)
+		}
+		assert.Equal(t, waitLock, true)
+	}
+
+	// should acquire successfully after release
+	{
+		waitCh := make(chan struct{})
+		go func() {
+			defer close(waitCh)
+
+			km.Lock(ctx, "c1")
+		}()
+		checkWaitFn("c1", 2)
+
+		km.Unlock("c1")
+
+		<-waitCh
+		assert.Equal(t, km.locks["c1"].ref, 1)
+	}
+
+	// failed to acquire if context cancel
+	{
+		var errCh = make(chan error, 1)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			errCh <- km.Lock(ctx, "c1")
+		}()
+
+		checkWaitFn("c1", 2)
+
+		cancel()
+		assert.Equal(t, <-errCh, context.Canceled)
+		assert.Equal(t, km.locks["c1"].ref, 1)
+	}
+}
+
+func TestReleasePanic(t *testing.T) {
+	t.Parallel()
+
+	km := newKeyMutex()
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("release of unlocked key did not panic")
+		}
+	}()
+
+	km.Unlock(t.Name())
+}
+
+func TestMultileAcquireOnKeys(t *testing.T) {
+	t.Parallel()
+
+	km := newKeyMutex()
+	nloops := 10000
+	nproc := runtime.GOMAXPROCS(0)
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	for i := 0; i < nproc; i++ {
+		wg.Add(1)
+
+		go func(key string) {
+			defer wg.Done()
+
+			for i := 0; i < nloops; i++ {
+				km.Lock(ctx, key)
+
+				time.Sleep(time.Duration(rand.Int63n(100)) * time.Nanosecond)
+
+				km.Unlock(key)
+			}
+		}("key-" + strconv.Itoa(i))
+	}
+	wg.Wait()
+}
+
+func TestMultiAcquireOnSameKey(t *testing.T) {
+	t.Parallel()
+
+	km := newKeyMutex()
+	key := "c1"
+	ctx := context.Background()
+
+	assert.Nil(t, km.Lock(ctx, key))
+
+	nproc := runtime.GOMAXPROCS(0)
+	nloops := 10000
+
+	var wg sync.WaitGroup
+	for i := 0; i < nproc; i++ {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			for i := 0; i < nloops; i++ {
+				km.Lock(ctx, key)
+
+				time.Sleep(time.Duration(rand.Int63n(100)) * time.Nanosecond)
+
+				km.Unlock(key)
+			}
+		}()
+	}
+	km.Unlock(key)
+	wg.Wait()
+
+	// c1 key has been released so the it should not have any klock.
+	assert.Equal(t, len(km.locks), 0)
+}

--- a/pkg/kmutex/noop.go
+++ b/pkg/kmutex/noop.go
@@ -1,0 +1,33 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package kmutex
+
+import "context"
+
+func NewNoop() KeyedLocker {
+	return &noopMutex{}
+}
+
+type noopMutex struct {
+}
+
+func (*noopMutex) Lock(_ context.Context, _ string) error {
+	return nil
+}
+
+func (*noopMutex) Unlock(_ string) {
+}

--- a/services/server/config/config.go
+++ b/services/server/config/config.go
@@ -186,6 +186,9 @@ type BoltConfig struct {
 	// bandwidth across namespaces, at the cost of allowing access to any blob
 	// just by knowing its digest.
 	ContentSharingPolicy string `toml:"content_sharing_policy"`
+
+	// SnapshotSharingPolicy is same as ContentSharingPolicy but for snapshots.
+	SnapshotSharingPolicy string `toml:"snapshot_sharing_policy"`
 }
 
 const (
@@ -199,10 +202,17 @@ const (
 func (bc *BoltConfig) Validate() error {
 	switch bc.ContentSharingPolicy {
 	case SharingPolicyShared, SharingPolicyIsolated:
-		return nil
 	default:
 		return fmt.Errorf("unknown policy: %s: %w", bc.ContentSharingPolicy, errdefs.ErrInvalidArgument)
 	}
+
+	switch bc.SnapshotSharingPolicy {
+	case SharingPolicyShared, SharingPolicyIsolated:
+	default:
+		return fmt.Errorf("unknown policy: %s: %w", bc.SnapshotSharingPolicy, errdefs.ErrInvalidArgument)
+	}
+
+	return nil
 }
 
 // Decode unmarshals a plugin specific configuration by plugin id

--- a/services/server/server.go
+++ b/services/server/server.go
@@ -403,7 +403,8 @@ func LoadPlugins(ctx context.Context, config *srvconfig.Config) ([]*plugin.Regis
 			plugin.SnapshotPlugin,
 		},
 		Config: &srvconfig.BoltConfig{
-			ContentSharingPolicy: srvconfig.SharingPolicyShared,
+			ContentSharingPolicy:  srvconfig.SharingPolicyShared,
+			SnapshotSharingPolicy: srvconfig.SharingPolicyIsolated,
 		},
 		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
 			if err := os.MkdirAll(ic.Root, 0711); err != nil {
@@ -432,19 +433,35 @@ func LoadPlugins(ctx context.Context, config *srvconfig.Config) ([]*plugin.Regis
 				snapshotters[name] = sn.(snapshots.Snapshotter)
 			}
 
-			shared := true
-			ic.Meta.Exports["policy"] = srvconfig.SharingPolicyShared
+			contentShared := true
+			ic.Meta.Exports["content_policy"] = srvconfig.SharingPolicyShared
 			if cfg, ok := ic.Config.(*srvconfig.BoltConfig); ok {
 				if cfg.ContentSharingPolicy != "" {
 					if err := cfg.Validate(); err != nil {
 						return nil, err
 					}
 					if cfg.ContentSharingPolicy == srvconfig.SharingPolicyIsolated {
-						ic.Meta.Exports["policy"] = srvconfig.SharingPolicyIsolated
-						shared = false
+						ic.Meta.Exports["content_policy"] = srvconfig.SharingPolicyIsolated
+						contentShared = false
 					}
 
-					log.L.WithField("policy", cfg.ContentSharingPolicy).Info("metadata content store policy set")
+					log.L.WithField("content_policy", cfg.ContentSharingPolicy).Info("metadata content store policy set")
+				}
+			}
+
+			snapshotShared := false
+			ic.Meta.Exports["snapshot_policy"] = srvconfig.SharingPolicyIsolated
+			if cfg, ok := ic.Config.(*srvconfig.BoltConfig); ok {
+				if cfg.SnapshotSharingPolicy != "" {
+					if err := cfg.Validate(); err != nil {
+						return nil, err
+					}
+					if cfg.SnapshotSharingPolicy == srvconfig.SharingPolicyShared {
+						ic.Meta.Exports["snapshot_policy"] = srvconfig.SharingPolicyShared
+						snapshotShared = true
+					}
+
+					log.L.WithField("snapshot_policy", cfg.ContentSharingPolicy).Info("metadata snapshot policy set")
 				}
 			}
 
@@ -470,8 +487,11 @@ func LoadPlugins(ctx context.Context, config *srvconfig.Config) ([]*plugin.Regis
 			}
 
 			var dbopts []metadata.DBOpt
-			if !shared {
-				dbopts = append(dbopts, metadata.WithPolicyIsolated)
+			if !contentShared {
+				dbopts = append(dbopts, metadata.WithContentPolicyIsolated)
+			}
+			if snapshotShared {
+				dbopts = append(dbopts, metadata.WithSnapshotPolicyShared)
 			}
 			mdb := metadata.NewDB(db, cs.(content.Store), snapshotters, dbopts...)
 			if err := mdb.Init(ic.Context); err != nil {

--- a/unpacker.go
+++ b/unpacker.go
@@ -32,6 +32,7 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/pkg/kmutex"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/snapshots"
 	"github.com/opencontainers/go-digest"
@@ -59,7 +60,9 @@ func (c *Client) newUnpacker(ctx context.Context, rCtx *RemoteContext) (*unpacke
 	if err != nil {
 		return nil, err
 	}
-	var config UnpackConfig
+	var config = UnpackConfig{
+		DuplicationSuppressor: kmutex.NewNoop(),
+	}
 	for _, o := range rCtx.UnpackOpts {
 		if err := o(ctx, &config); err != nil {
 			return nil, err
@@ -127,15 +130,20 @@ func (u *unpacker) unpack(
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-EachLayer:
-	for i, desc := range layers {
+	doUnpackFn := func(i int, desc ocispec.Descriptor) error {
 		parent := identity.ChainID(chain)
 		chain = append(chain, diffIDs[i])
-
 		chainID := identity.ChainID(chain).String()
+
+		unlock, err := u.lockSnChainID(ctx, chainID)
+		if err != nil {
+			return err
+		}
+		defer unlock()
+
 		if _, err := sn.Stat(ctx, chainID); err == nil {
 			// no need to handle
-			continue
+			return nil
 		} else if !errdefs.IsNotFound(err) {
 			return fmt.Errorf("failed to stat snapshot %s: %w", chainID, err)
 		}
@@ -167,7 +175,7 @@ EachLayer:
 						log.G(ctx).WithField("key", key).WithField("chainid", chainID).Debug("extraction snapshot already exists, chain id not found")
 					} else {
 						// no need to handle, snapshot now found with chain id
-						continue EachLayer
+						return nil
 					}
 				} else {
 					return fmt.Errorf("failed to prepare extraction snapshot %q: %w", key, err)
@@ -227,7 +235,7 @@ EachLayer:
 		if err = sn.Commit(ctx, chainID, key, opts...); err != nil {
 			abort()
 			if errdefs.IsAlreadyExists(err) {
-				continue
+				return nil
 			}
 			return fmt.Errorf("failed to commit snapshot %s: %w", key, err)
 		}
@@ -243,7 +251,13 @@ EachLayer:
 		if _, err := cs.Update(ctx, cinfo, "labels.containerd.io/uncompressed"); err != nil {
 			return err
 		}
+		return nil
+	}
 
+	for i, desc := range layers {
+		if err := doUnpackFn(i, desc); err != nil {
+			return err
+		}
 	}
 
 	chainID := identity.ChainID(chain).String()
@@ -271,17 +285,22 @@ func (u *unpacker) fetch(ctx context.Context, h images.Handler, layers []ocispec
 		desc := desc
 		i := i
 
-		if u.limiter != nil {
-			if err := u.limiter.Acquire(ctx, 1); err != nil {
-				return err
-			}
+		if err := u.acquire(ctx); err != nil {
+			return err
 		}
 
 		eg.Go(func() error {
-			_, err := h.Handle(ctx2, desc)
-			if u.limiter != nil {
-				u.limiter.Release(1)
+			unlock, err := u.lockBlobDescriptor(ctx2, desc)
+			if err != nil {
+				u.release()
+				return err
 			}
+
+			_, err = h.Handle(ctx2, desc)
+
+			unlock()
+			u.release()
+
 			if err != nil && !errors.Is(err, images.ErrSkipDesc) {
 				return err
 			}
@@ -306,7 +325,13 @@ func (u *unpacker) handlerWrapper(
 			layers = map[digest.Digest][]ocispec.Descriptor{}
 		)
 		return images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+			unlock, err := u.lockBlobDescriptor(ctx, desc)
+			if err != nil {
+				return nil, err
+			}
+
 			children, err := f.Handle(ctx, desc)
+			unlock()
 			if err != nil {
 				return children, err
 			}
@@ -347,6 +372,50 @@ func (u *unpacker) handlerWrapper(
 			return children, nil
 		})
 	}, eg
+}
+
+func (u *unpacker) acquire(ctx context.Context) error {
+	if u.limiter == nil {
+		return nil
+	}
+	return u.limiter.Acquire(ctx, 1)
+}
+
+func (u *unpacker) release() {
+	if u.limiter == nil {
+		return
+	}
+	u.limiter.Release(1)
+}
+
+func (u *unpacker) lockSnChainID(ctx context.Context, chainID string) (func(), error) {
+	key := u.makeChainIDKeyWithSnapshotter(chainID)
+
+	if err := u.config.DuplicationSuppressor.Lock(ctx, key); err != nil {
+		return nil, err
+	}
+	return func() {
+		u.config.DuplicationSuppressor.Unlock(key)
+	}, nil
+}
+
+func (u *unpacker) lockBlobDescriptor(ctx context.Context, desc ocispec.Descriptor) (func(), error) {
+	key := u.makeBlobDescriptorKey(desc)
+
+	if err := u.config.DuplicationSuppressor.Lock(ctx, key); err != nil {
+		return nil, err
+	}
+	return func() {
+		u.config.DuplicationSuppressor.Unlock(key)
+	}, nil
+}
+
+func (u *unpacker) makeChainIDKeyWithSnapshotter(chainID string) string {
+	return fmt.Sprintf("sn://%s/%v", u.snapshotter, chainID)
+}
+
+func (u *unpacker) makeBlobDescriptorKey(desc ocispec.Descriptor) string {
+	return fmt.Sprintf("blob://%v", desc.Digest)
 }
 
 func uniquePart() string {

--- a/unpacker.go
+++ b/unpacker.go
@@ -158,7 +158,7 @@ EachLayer:
 			key = fmt.Sprintf(snapshots.UnpackKeyFormat, uniquePart(), chainID)
 			mounts, err = sn.Prepare(ctx, key, parent.String(), opts...)
 			if err != nil {
-				if errdefs.IsAlreadyExists(err) {
+				if errdefs.IsAlreadyExists(err) || snapshots.IsTargetSnapshotExists(err) {
 					if _, err := sn.Stat(ctx, chainID); err != nil {
 						if !errdefs.IsNotFound(err) {
 							return fmt.Errorf("failed to stat snapshot %s: %w", chainID, err)


### PR DESCRIPTION
Contents in different namespaces can be shared by setting the content sharing policy. This
change adds the support for doing the same for snapshots. If same image is pulled and
extracted in different namespaces the same image layers will be extracted in multiple
namespaces. The snapshots created for these extracted layers contain the exact same
content. To avoid this duplication of work in improve the performance of image pull (if
the same image is already pulled in another namespace) snapshots of existing layers can be
shared across namespaces. Setting the newly added snapshot sharing policy will enable this.

Adding following to containerd.toml should enable this.

```
  [plugins.bolt]
        snapshot_sharing_policy = "shared"
```


Signed-off-by: Amit Barve <ambarve@microsoft.com>